### PR TITLE
optimized usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ A static blog template built with [Astro](https://astro.build).
 2. To edit your blog locally, clone your repository, run `pnpm install` AND `pnpm add sharp` to install dependencies.  
    - Install [pnpm](https://pnpm.io) `npm install -g pnpm` if you haven't.
 3. Edit the config file `src/config.ts` to customize your blog.
-4. Run `pnpm new-post <filename>` to create a new post and edit it in `src/content/posts/`.
-5. Deploy your blog to Vercel, Netlify, GitHub Pages, etc. following [the guides](https://docs.astro.build/en/guides/deploy/).
+4. Change the `site` field in `astro.config.mjs` to your blog's domain.
+5. Run `pnpm new-post <filename>` to create a new post and edit it in `src/content/posts/`.
+6. Deploy your blog to Vercel, Netlify, GitHub Pages, etc. following [the guides](https://docs.astro.build/en/guides/deploy/).
 
 ## ⚙️ Frontmatter of Posts
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,8 +23,9 @@
 2. 进行本地开发，Clone 新的仓库，执行 `pnpm install` 和 `pnpm add sharp` 以安装依赖  
    - 若未安装 [pnpm](https://pnpm.io)，执行 `npm install -g pnpm`
 3. 通过配置文件 `src/config.ts` 自定义博客
-4. 执行 `pnpm new-post <filename>` 创建新文章，并在 `src/content/posts/` 目录中编辑
-5. 参考[官方指南](https://docs.astro.build/zh-cn/guides/deploy/)将博客部署至 Vercel, Netlify, GitHub Pages 等 
+4. 将 `astro.config.mjs` 中的 `site` 字段修改为博客的域名
+5. 执行 `pnpm new-post <filename>` 创建新文章，并在 `src/content/posts/` 目录中编辑
+6. 参考[官方指南](https://docs.astro.build/zh-cn/guides/deploy/)将博客部署至 Vercel, Netlify, GitHub Pages 等 
 
 ## ⚙️ 文章 Frontmatter
 


### PR DESCRIPTION
README中“使用方法”缺少了修改 `site` 字段的步骤，会导致文章尾部 LICENSE 中的链接仍然指向 `fuwari.versel.app`，而非用户自己的博客域名。

![image](https://github.com/saicaca/fuwari/assets/45226780/fc9ed183-c1a6-4619-b70d-e4f1d4bb2d8d)
