### PR TITLE
feat: extract siteUrl into `src/config.ts`

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,7 @@ import remarkMath from "remark-math"
 import { remarkReadingTime } from "./src/plugins/remark-reading-time.mjs"
 import svelte from "@astrojs/svelte"
 import swup from '@swup/astro';
+import { siteConfig } from "./src/config";
 
 const oklchToHex = (str) => {
   const DEFAULT_HUE = 250
@@ -23,7 +24,7 @@ const oklchToHex = (str) => {
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://fuwari.vercel.app/",
+  site: siteConfig.url,
   base: "/",
   integrations: [
     tailwind(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ import { LinkPreset } from './types/config'
 export const siteConfig: SiteConfig = {
   title: 'Fuwari',
   subtitle: 'Demo Site',
+  url: 'https://fuwari.vercel.app',
   lang: 'en',
   themeHue: 250,
   banner: {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,6 +1,7 @@
 export type SiteConfig = {
   title: string
   subtitle: string
+  url: string
 
   lang: string
 


### PR DESCRIPTION
**Propose:** I believe it is better if you can configure all settings in one config. 
**Change:** Move the site URL settings from `astro.config.mjs` to `siteConfig` in  `src/config.ts`.

**Note:**  
Both `https://fuwari.vercel.app/` and `https://fuwari.vercel.app (without "/")` will do. 

Tested from my staging site:  
![image](https://github.com/saicaca/fuwari/assets/142381267/9364bbef-d817-42e8-97e7-95614cbe8307)
