### PR TITLE
feat: using rel="me" to verify ownership for websites

### DIFF
--- a/src/components/widget/Profile.astro
+++ b/src/components/widget/Profile.astro
@@ -22,7 +22,7 @@ const config = profileConfig;
     <div class="text-center text-neutral-400 mb-2.5 transition">{config.bio}</div>
     <div class="flex gap-2 mx-2 justify-center mb-4">
         {config.links.map(item =>
-            <a aria-label={item.name} href={item.url} target="_blank" class="btn-regular rounded-lg h-10 w-10 active:scale-90">
+            <a rel="me" aria-label={item.name} href={item.url} target="_blank" class="btn-regular rounded-lg h-10 w-10 active:scale-90">
                 <Icon name={item.icon} size="1.5rem"></Icon>
             </a>
         )}


### PR DESCRIPTION
**Proposed change:** 
Verify the target link is presented by the same person: 
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/me

**Example scenario:** 
Mastodon profile

**Demo**: 
Working as intended:
![image](https://github.com/saicaca/fuwari/assets/142381267/4e5be04d-a3a8-4782-91d6-a801bbe5d4c9)

**Additional:**
As comparison, GitHub profile is doing the same thing:
![image](https://github.com/saicaca/fuwari/assets/142381267/2a10148e-aa2d-41bb-8796-17541fcfe0f9)

I can't consider a reason why `nofollow` should be added for blog scenarios, so I only add `me`.