### PR TITLE
feat: enhanced meta for social sharing (basic)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -76,6 +76,18 @@ const favicons: Favicon[] = siteConfig.favicon.length > 0 ? siteConfig.favicon :
 
 		<meta charset="UTF-8" />
 		<meta name="description" content={description || pageTitle}>
+		<meta name="author" content={profileConfig.name}>
+
+		<meta property="og:site_name" content={siteConfig.title}>
+		<meta property="og:url" content={Astro.url}>
+		<meta property="og:title" content={pageTitle}>
+		<meta property="og:description" content={description || pageTitle}>
+
+		<meta name="twitter:card" content="summary_large_image">
+		<meta property="twitter:url" content={Astro.url}>
+		<meta name="twitter:title" content={pageTitle}>
+		<meta name="twitter:description" content={description || pageTitle}>
+
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
 		{favicons.map(favicon => (


### PR DESCRIPTION
**Proposed changes:** 
Enhance meta in header for social sharing based on PR (https://github.com/saicaca/fuwari/pull/56). The current version still presents bad in social media like Telegram.

**Before/After:**
Domain -> Site name
![image](https://github.com/saicaca/fuwari/assets/142381267/fb3ac22e-290a-46fb-a95c-04250cf4a7f8)

I don't think I have time to add "keyword" and "image" in meta list. As suggestion, `og:type=article` should be added when the page type is post. Same for `og:image`, `article:published_time`, `article:tag`, etc. This will make SEO outcome better.  

If I really have free time for this (I want to concentrate on my blog content for now) and not have been merged yet, I will try update some others in the same PR.

