### PR TITLE
Add Markdown Code Block Copy Functionality.

### DIFF
--- a/src/components/misc/Markdown.astro
+++ b/src/components/misc/Markdown.astro
@@ -14,46 +14,52 @@ const className = Astro.props.class;
 </div>
 
 <script>
-  import { i18n } from "../../i18n/translation";
-  import I18nKey from "../../i18n/i18nKey";
+  import { i18n } from "@i18n/translation";
+  import I18nKey from "@i18n/i18nKey";
 
-  const copyButtonLabel = i18n(I18nKey.codeCopy);
-  const codeBlocks = Array.from(document.querySelectorAll("pre"));
+  const observer = new MutationObserver(addPreCopyButton);
+  observer.observe(document.body, { childList: true, subtree: true });
+  
+  document.addEventListener("DOMContentLoaded", addPreCopyButton);
 
-  for (const codeBlock of codeBlocks) {
-    const wrapper = document.createElement("div");
-    wrapper.className = "relative";
+  function addPreCopyButton() {
+    observer.disconnect();
+    
+    let codeBlocks = Array.from(document.querySelectorAll("pre"));
 
-    const copyButton = document.createElement("button");
-    copyButton.className = "copy-code btn-regular absolute top-0 right-0 text-sm px-3 py-2 rounded-bl-lg rounded-tr-lg";
-    copyButton.textContent = copyButtonLabel;
+    for (let codeBlock of codeBlocks) {
+      let wrapper = document.createElement("div");
+      wrapper.className = "relative";
 
-    codeBlock.setAttribute("tabindex", "0");
-    if (codeBlock.parentNode) {
-      codeBlock.parentNode.insertBefore(wrapper, codeBlock);
+      let copyButton = document.createElement("button");
+      copyButton.className = "copy-code btn-regular absolute top-0 right-0 text-sm px-3 py-2 rounded-bl-lg rounded-tr-lg opacity-75";
+      copyButton.textContent = i18n(I18nKey.codeCopy);
+
+      codeBlock.setAttribute("tabindex", "0");
+      if (codeBlock.parentNode) {
+        codeBlock.parentNode.insertBefore(wrapper, codeBlock);
+      }
+
+      wrapper.appendChild(codeBlock);
+      wrapper.appendChild(copyButton);
+
+      copyButton.addEventListener("click", async () => {
+        let text = codeBlock?.querySelector("code")?.innerText;
+
+        await navigator.clipboard.writeText(text);
+
+        copyButton.textContent = i18n(I18nKey.codeCopied);
+
+        setTimeout(() => {
+          copyButton.textContent = i18n(I18nKey.codeCopy);
+        }, 700);
+      });
     }
-
-    wrapper.appendChild(codeBlock);
-    wrapper.appendChild(copyButton);
-
-    copyButton.addEventListener("click", async () => {
-      await copyCode(codeBlock, copyButton);
-    });
-  }
-
-  async function copyCode(block, button) {
-    const code = block.querySelector("code");
-    const text = code.innerText;
-
-    await navigator.clipboard.writeText(text);
-
-    button.textContent = i18n(I18nKey.codeCopied);
-
-    setTimeout(() => {
-      button.textContent = copyButtonLabel;
-    }, 700);
+    
+    observer.observe(document.body, { childList: true, subtree: true });
   }
 </script>
+
 
 <style lang="stylus" is:global>
   .custom-md

--- a/src/components/misc/Markdown.astro
+++ b/src/components/misc/Markdown.astro
@@ -32,7 +32,7 @@ const className = Astro.props.class;
       wrapper.className = "relative";
 
       let copyButton = document.createElement("button");
-      copyButton.className = "copy-code btn-regular absolute top-0 right-0 text-sm px-3 py-2 rounded-bl-lg rounded-tr-lg opacity-75";
+      copyButton.className = "copy-code btn-regular absolute top-0 right-0 text-sm px-3 py-2 rounded-bl-lg rounded-tr-lg opacity-75 hover:opacity-100 transition-all duration-200 ease-in-out";
       copyButton.textContent = i18n(I18nKey.codeCopy);
 
       codeBlock.setAttribute("tabindex", "0");
@@ -49,9 +49,11 @@ const className = Astro.props.class;
         await navigator.clipboard.writeText(text);
 
         copyButton.textContent = i18n(I18nKey.codeCopied);
+        copyButton.classList.toggle("opacity-100");
 
         setTimeout(() => {
           copyButton.textContent = i18n(I18nKey.codeCopy);
+          copyButton.classList.toggle("opacity-100");
         }, 700);
       });
     }

--- a/src/components/misc/Markdown.astro
+++ b/src/components/misc/Markdown.astro
@@ -25,15 +25,16 @@ const className = Astro.props.class;
     wrapper.className = "relative";
 
     const copyButton = document.createElement("button");
-    copyButton.className = "copy-code btn-regular absolute top-0 right-0 text-sm px-3 py-2 rounded-bl-lg";
+    copyButton.className = "copy-code btn-regular absolute top-0 right-0 text-sm px-3 py-2 rounded-bl-lg rounded-tr-lg";
     copyButton.textContent = copyButtonLabel;
 
     codeBlock.setAttribute("tabindex", "0");
-    codeBlock.appendChild(copyButton);
     if (codeBlock.parentNode) {
       codeBlock.parentNode.insertBefore(wrapper, codeBlock);
     }
+
     wrapper.appendChild(codeBlock);
+    wrapper.appendChild(copyButton);
 
     copyButton.addEventListener("click", async () => {
       await copyCode(codeBlock, copyButton);

--- a/src/components/misc/Markdown.astro
+++ b/src/components/misc/Markdown.astro
@@ -28,8 +28,10 @@ const className = Astro.props.class;
     let codeBlocks = Array.from(document.querySelectorAll("pre"));
 
     for (let codeBlock of codeBlocks) {
+      if (codeBlock.parentElement?.nodeName === "DIV" && codeBlock.parentElement?.classList.contains("code-block")) continue
+
       let wrapper = document.createElement("div");
-      wrapper.className = "relative";
+      wrapper.className = "relative code-block";
 
       let copyButton = document.createElement("button");
       copyButton.className = "copy-code btn-regular absolute top-0 right-0 text-sm px-3 py-2 rounded-bl-lg rounded-tr-lg opacity-75 hover:opacity-100 transition-all duration-200 ease-in-out";

--- a/src/components/misc/Markdown.astro
+++ b/src/components/misc/Markdown.astro
@@ -13,6 +13,47 @@ const className = Astro.props.class;
     <slot />
 </div>
 
+<script>
+  import { i18n } from "../../i18n/translation";
+  import I18nKey from "../../i18n/i18nKey";
+
+  const copyButtonLabel = i18n(I18nKey.codeCopy);
+  const codeBlocks = Array.from(document.querySelectorAll("pre"));
+
+  for (const codeBlock of codeBlocks) {
+    const wrapper = document.createElement("div");
+    wrapper.className = "relative";
+
+    const copyButton = document.createElement("button");
+    copyButton.className = "copy-code btn-regular absolute top-0 right-0 text-sm px-3 py-2 rounded-bl-lg";
+    copyButton.textContent = copyButtonLabel;
+
+    codeBlock.setAttribute("tabindex", "0");
+    codeBlock.appendChild(copyButton);
+    if (codeBlock.parentNode) {
+      codeBlock.parentNode.insertBefore(wrapper, codeBlock);
+    }
+    wrapper.appendChild(codeBlock);
+
+    copyButton.addEventListener("click", async () => {
+      await copyCode(codeBlock, copyButton);
+    });
+  }
+
+  async function copyCode(block, button) {
+    const code = block.querySelector("code");
+    const text = code.innerText;
+
+    await navigator.clipboard.writeText(text);
+
+    button.textContent = i18n(I18nKey.codeCopied);
+
+    setTimeout(() => {
+      button.textContent = copyButtonLabel;
+    }, 700);
+  }
+</script>
+
 <style lang="stylus" is:global>
   .custom-md
     h1,h2,h3,h4,h5,h6

--- a/src/i18n/i18nKey.ts
+++ b/src/i18n/i18nKey.ts
@@ -27,6 +27,9 @@ enum I18nKey {
   author = 'author',
   publishedAt = 'publishedAt',
   license = 'license',
+
+  codeCopy = 'copy',
+  codeCopied = 'codeCopied',
 }
 
 export default I18nKey

--- a/src/i18n/languages/en.ts
+++ b/src/i18n/languages/en.ts
@@ -30,4 +30,7 @@ export const en: Translation = {
   [Key.author]: 'Author',
   [Key.publishedAt]: 'Published at',
   [Key.license]: 'License',
+
+  [Key.codeCopy]: 'Copy',
+  [Key.codeCopied]: 'Code copied',
 }

--- a/src/i18n/languages/ja.ts
+++ b/src/i18n/languages/ja.ts
@@ -30,4 +30,7 @@ export const ja: Translation = {
   [Key.author]: '作者',
   [Key.publishedAt]: '公開日',
   [Key.license]: 'ライセンス',
+
+  [Key.codeCopy]: 'コピー',
+  [Key.codeCopied]: 'コピーしました',
 }

--- a/src/i18n/languages/zh_CN.ts
+++ b/src/i18n/languages/zh_CN.ts
@@ -30,4 +30,7 @@ export const zh_CN: Translation = {
   [Key.author]: '作者',
   [Key.publishedAt]: '发布于',
   [Key.license]: '许可协议',
+
+  [Key.codeCopy]: '复制',
+  [Key.codeCopied]: '复制成功',
 }

--- a/src/i18n/languages/zh_TW.ts
+++ b/src/i18n/languages/zh_TW.ts
@@ -30,4 +30,7 @@ export const zh_TW: Translation = {
   [Key.author]: '作者',
   [Key.publishedAt]: '發佈於',
   [Key.license]: '許可協議',
+
+  [Key.codeCopy]: '複製',
+  [Key.codeCopied]: '複製成功',
 }


### PR DESCRIPTION
Add a copy button to the top-right corner of a Markdown code block.
<img width="829" alt="image" src="https://github.com/saicaca/fuwari/assets/20947392/7c0c06d8-1ed6-4629-8bb2-b3284e149670">
