### PR TITLE
feat: set the zoom width and height for remote image

### DIFF
--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -153,12 +153,12 @@ function createPhotoSwipe() {
     pswpModule: () => import("photoswipe"),
   })
 
-  lightbox.addFilter("domItemData", (itemData, element, linkEl) => {
+  lightbox.addFilter("domItemData", (itemData, element) => {
     if (element instanceof HTMLImageElement) {
       itemData.src = element.src
 
-      itemData.w = Number(element.getAttribute("width"))
-      itemData.h = Number(element.getAttribute("height"))
+      itemData.w = Number(element.naturalWidth || window.innerWidth)
+      itemData.h = Number(element.naturalHeight || window.innerHeight)
 
       itemData.msrc = element.src
     }


### PR DESCRIPTION
PhotoSwipe needs to specify the zoom width and height.

1. Display image zoom when remote image metadata is parsed (img element with valid naturalWidth and naturalHeight properties).
2. Show `The image cannot be loaded` on failed image load.
