### PR TITLE
feat: add language as post property

### DIFF
--- a/frontmatter.json
+++ b/frontmatter.json
@@ -55,6 +55,11 @@
           "title": "draft",
           "name": "draft",
           "type": "boolean"
+        },
+        {
+          "title": "language",
+          "name": "language",
+          "type": "string"
         }
       ]
     }

--- a/scripts/new-post.js
+++ b/scripts/new-post.js
@@ -44,6 +44,7 @@ image: ''
 tags: []
 category: ''
 draft: false 
+language: ''
 ---
 `
 

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -9,6 +9,7 @@ const postsCollection = defineCollection({
     image: z.string().optional().default(''),
     tags: z.array(z.string()).optional().default([]),
     category: z.string().optional().default(''),
+    language: z.string().optional().default(''),
 
     /* For internal use */
     prevTitle: z.string().default(''),

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,12 +18,13 @@ import type { Favicon } from '../types/config'
 import { url, pathsEqual } from '../utils/url-utils'
 
 interface Props {
-  title?: string
-  banner?: string
-  description?: string
+	title?: string
+	banner?: string
+	description?: string
+	lang?: string
 }
 
-let { title, banner, description } = Astro.props
+let { title, banner, description, lang } = Astro.props
 
 // apply a class to the body element to decide the height of the banner, only used for initial page load
 // Swup can update the body for each page visit, but it's after the page transition, causing a delay for banner height change
@@ -52,7 +53,11 @@ if (title) {
 const favicons: Favicon[] =
   siteConfig.favicon.length > 0 ? siteConfig.favicon : defaultFavicons
 
-const siteLang = siteConfig.lang.replace('_', '-')
+// const siteLang = siteConfig.lang.replace('_', '-')
+if (!lang) {
+	lang = `${siteConfig.lang}`
+}
+const siteLang = lang.replace('_', '-')
 ---
 
 <!DOCTYPE html>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,10 +18,10 @@ import type { Favicon } from '../types/config'
 import { url, pathsEqual } from '../utils/url-utils'
 
 interface Props {
-	title?: string
-	banner?: string
-	description?: string
-	lang?: string
+  title?: string
+  banner?: string
+  description?: string
+  lang?: string
 }
 
 let { title, banner, description, lang } = Astro.props
@@ -55,7 +55,7 @@ const favicons: Favicon[] =
 
 // const siteLang = siteConfig.lang.replace('_', '-')
 if (!lang) {
-	lang = `${siteConfig.lang}`
+  lang = `${siteConfig.lang}`
 }
 const siteLang = lang.replace('_', '-')
 ---

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -8,18 +8,19 @@ import { Icon } from 'astro-icon/components'
 import { siteConfig } from '../config'
 
 interface Props {
-  title?: string
-  banner?: string
-  description?: string
+    title?: string
+    banner?: string
+    description?: string
+    lang?: string
 }
 
-const { title, banner, description } = Astro.props
+const { title, banner, description , lang} = Astro.props
 const hasBannerCredit =
   siteConfig.banner.enable && siteConfig.banner.credit.enable
 const hasBannerLink = !!siteConfig.banner.credit.url
 ---
 
-<Layout title={title} banner={banner} description={description}>
+<Layout title={title} banner={banner} description={description} lang={lang}>
 <slot slot="head" name="head"></slot>
 <div class="max-w-[var(--page-width)] min-h-screen grid grid-cols-[17.5rem_auto] grid-rows-[auto_auto_1fr_auto] lg:grid-rows-[auto_1fr_auto]
     mx-auto gap-4 relative px-0 md:px-4"

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -14,7 +14,7 @@ interface Props {
     lang?: string
 }
 
-const { title, banner, description , lang} = Astro.props
+const { title, banner, description, lang} = Astro.props
 const hasBannerCredit =
   siteConfig.banner.enable && siteConfig.banner.credit.enable
 const hasBannerLink = !!siteConfig.banner.credit.url

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -8,13 +8,13 @@ import { Icon } from 'astro-icon/components'
 import { siteConfig } from '../config'
 
 interface Props {
-    title?: string
-    banner?: string
-    description?: string
-    lang?: string
+  title?: string
+  banner?: string
+  description?: string
+  lang?: string
 }
 
-const { title, banner, description, lang} = Astro.props
+const { title, banner, description, lang } = Astro.props
 const hasBannerCredit =
   siteConfig.banner.enable && siteConfig.banner.credit.enable
 const hasBannerLink = !!siteConfig.banner.credit.url

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -11,7 +11,7 @@ import { Icon } from 'astro-icon/components'
 import { licenseConfig } from 'src/config'
 import PostMetadata from '../../components/PostMeta.astro'
 import ImageWrapper from '../../components/misc/ImageWrapper.astro'
-import { profileConfig } from '../../config'
+import { profileConfig, siteConfig } from '../../config'
 import { formatDateToYYYYMMDD } from '../../utils/date-utils'
 
 export async function getStaticPaths() {
@@ -41,7 +41,7 @@ const jsonLd = {
     url: Astro.site,
   },
   datePublished: formatDateToYYYYMMDD(entry.data.published),
-  inLanguage: entry.data.language.replace('_', '-'),
+  inLanguage: siteConfig.lang.replace('_', '-'),
   // TODO include cover image here
 }
 ---

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -45,7 +45,7 @@ const jsonLd = {
     // TODO include cover image here
 }
 ---
-<MainGridLayout banner={entry.data.image} title={entry.data.title} description={entry.data.description} lang={entry.data.language.replace('_', '-')}>
+<MainGridLayout banner={entry.data.image} title={entry.data.title} description={entry.data.description} lang={entry.data.language}>
     <script is:inline slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
     <div class="flex w-full rounded-[var(--radius-large)] overflow-hidden relative mb-4">
         <div id="post-container" class:list={["card-base z-10 px-6 md:px-9 pt-6 pb-4 relative w-full ",

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -30,19 +30,19 @@ const { Content } = await entry.render()
 const { remarkPluginFrontmatter } = await entry.render()
 
 const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'BlogPosting',
-    headline: entry.data.title,
-    description: entry.data.description || entry.data.title,
-    keywords: entry.data.tags,
-    author: {
-        '@type': 'Person',
-        name: profileConfig.name,
-        url: Astro.site,
-    },
-    datePublished: formatDateToYYYYMMDD(entry.data.published),
-    inLanguage: entry.data.language.replace('_', '-'),
-    // TODO include cover image here
+  '@context': 'https://schema.org',
+  '@type': 'BlogPosting',
+  headline: entry.data.title,
+  description: entry.data.description || entry.data.title,
+  keywords: entry.data.tags,
+  author: {
+    '@type': 'Person',
+    name: profileConfig.name,
+    url: Astro.site,
+  },
+  datePublished: formatDateToYYYYMMDD(entry.data.published),
+  inLanguage: entry.data.language.replace('_', '-'),
+  // TODO include cover image here
 }
 ---
 <MainGridLayout banner={entry.data.image} title={entry.data.title} description={entry.data.description} lang={entry.data.language}>

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -30,21 +30,22 @@ const { Content } = await entry.render()
 const { remarkPluginFrontmatter } = await entry.render()
 
 const jsonLd = {
-  '@context': 'https://schema.org',
-  '@type': 'BlogPosting',
-  headline: entry.data.title,
-  description: entry.data.description || entry.data.title,
-  keywords: entry.data.tags,
-  author: {
-    '@type': 'Person',
-    name: profileConfig.name,
-    url: Astro.site,
-  },
-  datePublished: formatDateToYYYYMMDD(entry.data.published),
-  // TODO include cover image here
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: entry.data.title,
+    description: entry.data.description || entry.data.title,
+    keywords: entry.data.tags,
+    author: {
+        '@type': 'Person',
+        name: profileConfig.name,
+        url: Astro.site,
+    },
+    datePublished: formatDateToYYYYMMDD(entry.data.published),
+    inLanguage: entry.data.language.replace('_', '-'),
+    // TODO include cover image here
 }
 ---
-<MainGridLayout banner={entry.data.image} title={entry.data.title} description={entry.data.description}>
+<MainGridLayout banner={entry.data.image} title={entry.data.title} description={entry.data.description} lang={entry.data.language.replace('_', '-')}>
     <script is:inline slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
     <div class="flex w-full rounded-[var(--radius-large)] overflow-hidden relative mb-4">
         <div id="post-container" class:list={["card-base z-10 px-6 md:px-9 pt-6 pb-4 relative w-full ",

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -41,7 +41,7 @@ const jsonLd = {
     url: Astro.site,
   },
   datePublished: formatDateToYYYYMMDD(entry.data.published),
-  inLanguage: siteConfig.lang.replace('_', '-'),
+  inLanguage: (entry.data.language ? entry.data.language.replace('_', '-') : siteConfig.lang.replace('_', '-')),
   // TODO include cover image here
 }
 ---


### PR DESCRIPTION
Related issue: #150 

Users can specify the `language` type for individual posts by adding `language: en` (or `zh-CN`, `en-US`, etc. ) to the Markdown frontmatter. This allows for the customization of the `lang` attribute in the `<html>` tag, enhancing accessibility and improving search engine optimization.

Example of the Markdown frontmatter:

```markdown
---
title: Hello World
description: Here goes the description
published: 2024-08-12
draft: false
category: Casual
tags: []
language: en-US
---
```