### PR TITLE
fix: fixed github card component

### DIFF
--- a/src/plugins/rehype-component-github-card.mjs
+++ b/src/plugins/rehype-component-github-card.mjs
@@ -57,9 +57,14 @@ export function GithubCardComponent(properties, children) {
   const nScript = h(
     `script#${cardUuid}-script`,
     { type: 'text/javascript', defer: true },
+      //language=JavaScript
     `
       fetch('https://api.github.com/repos/${repo}', { referrerPolicy: "no-referrer" }).then(response => response.json()).then(data => {
-        document.getElementById('${cardUuid}-description').innerText = data.description.replace(/:[a-zA-Z0-9_]+:/g, '');
+        if (data.description) {
+          document.getElementById('${cardUuid}-description').innerText = data.description.replace(/:[a-zA-Z0-9_]+:/g, '');
+        } else {
+          document.getElementById('${cardUuid}-description').innerText = "Description not set"
+        }
         document.getElementById('${cardUuid}-language').innerText = data.language;
         document.getElementById('${cardUuid}-forks').innerText = Intl.NumberFormat('en-us', { notation: "compact", maximumFractionDigits: 1 }).format(data.forks).replaceAll("\u202f", '');
         document.getElementById('${cardUuid}-stars').innerText = Intl.NumberFormat('en-us', { notation: "compact", maximumFractionDigits: 1 }).format(data.stargazers_count).replaceAll("\u202f", '');

--- a/src/plugins/rehype-component-github-card.mjs
+++ b/src/plugins/rehype-component-github-card.mjs
@@ -57,7 +57,6 @@ export function GithubCardComponent(properties, children) {
   const nScript = h(
     `script#${cardUuid}-script`,
     { type: 'text/javascript', defer: true },
-      //language=JavaScript
     `
       fetch('https://api.github.com/repos/${repo}', { referrerPolicy: "no-referrer" }).then(response => response.json()).then(data => {
         if (data.description) {


### PR DESCRIPTION
If the description is empty for a repository, the card component would keep on loading in the frontend but in console it would report as error

fix:
check if `data.description` exists, and if it does, then do the original workflow,
otherwise, set `document.getElementById('${cardUuid}-description').innerText` to "Description not set"

note:
please feel free to set the text to what feels appropriate to you.