### PR TITLE
Fix Responsive Menu and DOM Errors When themeColor.fixed is Set to true

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -84,21 +84,31 @@ function switchTheme() {
 
 function loadButtonScript() {
     let switchBtn = document.getElementById("scheme-switch");
-    switchBtn!.addEventListener("click", function () {
-        switchTheme()
-    });
+    if (switchBtn) {
+        switchBtn.addEventListener("click", function () {
+            switchTheme()
+        });
+    }
 
     let settingBtn = document.getElementById("display-settings-switch");
-    settingBtn!.addEventListener("click", function () {
-        let settingPanel = document.getElementById("display-setting");
-        settingPanel!.classList.toggle("float-panel-closed");
-    });
+    if (settingBtn) {
+        settingBtn.addEventListener("click", function () {
+            let settingPanel = document.getElementById("display-setting");
+            if (settingPanel) {
+                settingPanel.classList.toggle("float-panel-closed");
+            }
+        });
+    }
 
     let menuBtn = document.getElementById("nav-menu-switch");
-    menuBtn!.addEventListener("click", function () {
-        let menuPanel = document.getElementById("nav-menu-panel");
-        menuPanel!.classList.toggle("float-panel-closed");
-    });
+    if (menuBtn) {
+        menuBtn.addEventListener("click", function () {
+            let menuPanel = document.getElementById("nav-menu-panel");
+            if (menuPanel) {
+                menuPanel.classList.toggle("float-panel-closed");
+            }
+        });
+    }
 }
 
 loadButtonScript();


### PR DESCRIPTION
This PR addresses an issue where the responsive menu fails to function correctly on small screens when the **_themeColor.fixed_** option in **_config.ts_** is set to **_true_**. The main cause was a TypeError occurring due to the absence of certain DOM elements when this configuration was active.

### Changes Made:
- Added conditional checks in the **_loadButtonScript_** function within **_Navbar.astro_** to ensure that elements like **_display-settings-switch_** and **_nav-menu-switch_** are present before attaching event listeners.
- This update prevents the script from attempting to access **_null_** elements, thus resolving the issue that caused the responsive menu to break.

### Issue Link:
This PR is linked to issue [#159](https://github.com/saicaca/fuwari/issues/159), which describes the problem in detail.