### PR TITLE
fix: remove blue outline on search

### DIFF
--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -117,3 +117,9 @@ top-20 left-4 md:left-[unset] right-4 shadow-2xl rounded-2xl p-2">
         </a>
     {/each}
 </div>
+
+<style>
+  input:focus {
+    outline: 0;
+  }
+</style>


### PR DESCRIPTION
This fixes #181 by adding the CSS suggested.

![image](https://github.com/user-attachments/assets/616a33fd-4bd1-43b3-bfdd-a3938736f220)

Search bar selected in Firefox