### PR TITLE
Dynamically generate copyright year 

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,6 +2,7 @@
 
 import { profileConfig } from '../config'
 import { url } from '../utils/url-utils'
+const currentYear = new Date().getFullYear()
 ---
 
 <!--<div class="border-t border-[var(&#45;&#45;primary)] mx-16 border-dashed py-8 max-w-[var(&#45;&#45;page-width)] flex flex-col items-center justify-center px-6">-->
@@ -9,7 +10,7 @@ import { url } from '../utils/url-utils'
 <!--<div class="transition bg-[oklch(92%_0.01_var(&#45;&#45;hue))] dark:bg-black rounded-2xl py-8 mt-4 mb-8 flex flex-col items-center justify-center px-6">-->
 <div class="transition border-dashed border-[oklch(85%_0.01_var(--hue))] dark:border-white/15 rounded-2xl mb-12 flex flex-col items-center justify-center px-6">
     <div class="transition text-50 text-sm text-center">
-        © 2024 {profileConfig.name}. All Rights Reserved. /
+        &copy; <span id="copyright-year">{currentYear}</span> {profileConfig.name}. All Rights Reserved. /
         <a class="transition link text-[var(--primary)] font-medium" target="_blank" href={url('rss.xml')}>RSS</a> /
         <a class="transition link text-[var(--primary)] font-medium" target="_blank" href={url('sitemap-index.xml')}>Sitemap</a><br>
         Powered by


### PR DESCRIPTION
**Proposed change:** Use server-side date to dynamically generate copyright year.

**Additional info:**
I considered the client-side date, by appending the following code to the end,
```html
<script>
  document.getElementById("copyright-year").innerText = new Date().getFullYear();
</script>
```

Overlooking the potential SEO issue (search engine will not execute the script on client side), it only works on desktop view, not working on mobile view. I cannot tell how to fix it. 
