### PR TITLE
(Concept) Use post banner as OpenGraph image, and a fallback site OG image

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ export const siteConfig: SiteConfig = {
       url: ''                // (Optional) URL link to the original artwork or artist's page
     }
   },
+  ogImage: '/og.webp',    // Default Open Graph image, relative to the /public directory
   toc: {
     enable: true,           // Display the table of contents on the right side of the post
     depth: 2                // Maximum heading depth to show in the table, from 1 to 3

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -31,6 +31,14 @@ interface Props {
 
 let { title, banner, description, lang, setOGTypeArticle } = Astro.props
 
+// Use post banner as page og image
+const openGraphImageUrl =
+	Astro.site +
+	(import.meta.env.BASE_URL.endsWith("/")
+		? import.meta.env.BASE_URL.slice(0, -1)
+		: import.meta.env.BASE_URL) +
+	(banner == undefined ? siteConfig.ogImage : banner);
+
 // apply a class to the body element to decide the height of the banner, only used for initial page load
 // Swup can update the body for each page visit, but it's after the page transition, causing a delay for banner height change
 // so use Swup hooks instead to change the height immediately when a link is clicked
@@ -89,6 +97,7 @@ const bannerOffset =
 		<meta property="og:url" content={Astro.url}>
 		<meta property="og:title" content={pageTitle}>
 		<meta property="og:description" content={description || pageTitle}>
+		<meta property="og:image" content={openGraphImageUrl} />
 		{setOGTypeArticle ? (
         <meta property="og:type" content="article" />
         ) : (
@@ -99,6 +108,7 @@ const bannerOffset =
 		<meta property="twitter:url" content={Astro.url}>
 		<meta name="twitter:title" content={pageTitle}>
 		<meta name="twitter:description" content={description || pageTitle}>
+		<meta property="twitter:image" content={openGraphImageUrl} />
 
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -20,6 +20,7 @@ export type SiteConfig = {
       url?: string
     }
   }
+  ogImage?: string
   toc: {
     enable: boolean
     depth: 1 | 2 | 3


### PR DESCRIPTION
I have a very crude implementation of using the post's banner image as the OG image for the page, and a fallback global site og image.

I do not expect this PR to be merged in this state, and request the community for improvements making the implementation much more robust. 