### PR TITLE
Abolish Corepack for packageManager management

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+manage-package-manager-versions = true

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "type-check": "tsc --noEmit --isolatedDeclarations",
     "new-post": "node scripts/new-post.js",
     "format": "biome format --write ./src",
-    "lint": "biome check --apply ./src"
+    "lint": "biome check --apply ./src",
+    "preinstall": "npx only-allow pnpm"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
@@ -65,5 +66,5 @@
     "@types/mdast": "^4.0.4",
     "@types/sanitize-html": "^2.13.0"
   },
-  "packageManager": "pnpm@9.6.0+sha512.38dc6fba8dba35b39340b9700112c2fe1e12f10b17134715a4aa98ccf7bb035e76fd981cf0bb384dfa98f8d6af5481c2bef2f4266a24bfa20c34eb7147ce0b5e"
+  "packageManager": "pnpm@9.14.4"
 }


### PR DESCRIPTION
close #228 #229 

- Use version control after pnpm9.7 by writing `manage-package-manager-versions = true` in .npmrc.
- update pnpm version
- Force use of pnpm.