### PR TITLE
added padding to ButtonLink badge div

### DIFF
--- a/src/components/control/ButtonLink.astro
+++ b/src/components/control/ButtonLink.astro
@@ -31,7 +31,7 @@ const { badge, url, label } = Astro.props
                 <slot></slot>
             </div>
             { badge !== undefined && badge !== null && badge !== '' &&
-                <div class="transition h-7 ml-4 min-w-[2rem] rounded-lg text-sm font-bold
+                <div class="transition px-2 h-7 ml-4 min-w-[2rem] rounded-lg text-sm font-bold
                     text-[var(--btn-content)] dark:text-[var(--deep-text)]
                     bg-[oklch(0.95_0.025_var(--hue))] dark:bg-[var(--primary)]
                     flex items-center justify-center">


### PR DESCRIPTION
When the number of posts in a category reaches 4 or even 3 digits the component does not look correct. I have added 2px padding to the ButtonLink badge div to fix this issue. That said, the fact that not all badges have the same width does not convince me but I am not a UX expert so I'll trust your judgement.

With the change it looks like this
<img width="301" alt="image" src="https://github.com/user-attachments/assets/a6c9ff7c-a31d-4a1c-a8ab-56e493f1c11a">

Without the change it looks like this
<img width="299" alt="image" src="https://github.com/user-attachments/assets/13d75039-b382-4cdc-8863-1856fa98b99c">

and it can get worse
<img width="297" alt="image" src="https://github.com/user-attachments/assets/5b036547-6790-4bf2-95be-0646d61929ea">

