### PR TITLE
Removing pointer-events from BackToTop wrapper

### DIFF
--- a/src/components/control/BackToTop.astro
+++ b/src/components/control/BackToTop.astro
@@ -18,6 +18,7 @@ import { Icon } from 'astro-icon/components'
     position: absolute
     right: 0
     top: 0
+    pointer-events: none
 
 .back-to-top-btn
     color: var(--primary)
@@ -29,6 +30,7 @@ import { Icon } from 'astro-icon/components'
     opacity: 1
     cursor: pointer
     transform: translateX(5rem)
+    pointer-events: auto
     i
         font-size: 1.75rem
     &.hide


### PR DESCRIPTION
The back-to-top wrapper element is hidden but blocks hover events from other elements that may overlap in the same position. NOTE that this does not affect any component in the current design. I happened to notice this on a different fork where it was causing an issue and therefore I suggest the change but feel free to ignore this if you think is not relevant enough or could cause problems with the back to top component.

<img width="658" alt="image" src="https://github.com/user-attachments/assets/ed202361-527c-4271-95fc-f5918d49d096" />
