### PR TITLE
fix: search component to client side only for svelte

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -44,7 +44,7 @@ let links: NavBarLink[] = navBarConfig.links.map(
         </div>
         <div class="flex">
             <!--<SearchPanel client:load>-->
-            <Search client:load></Search>
+            <Search client:only="svelte"></Search>
             {!siteConfig.themeColor.fixed && (
                     <button aria-label="Display Settings" class="btn-plain scale-animation rounded-lg h-11 w-11 active:scale-90" id="display-settings-switch">
                         <Icon name="material-symbols:palette-outline" class="text-[1.25rem]"></Icon>


### PR DESCRIPTION
### Description
This pull request fixes the issue where the search component was missing in production.

### Changes Made
- Replaced `client:load` with `client:only="svelte"` when rendering the search component to ensure proper loading in production.

### Related Issue
Fixes #253 