### PR TITLE
fix: The previous and next pages carry baseurl

### DIFF
--- a/src/components/control/Pagination.astro
+++ b/src/components/control/Pagination.astro
@@ -51,7 +51,7 @@ const getPageUrl = (p: number) => {
 ---
 
 <div class:list={[className, "flex flex-row gap-3 justify-center"]} style={style}>
-    <a href={url(page.url.prev || "")} aria-label={page.url.prev ? "Previous Page" : null}
+    <a href={page.url.prev || ""} aria-label={page.url.prev ? "Previous Page" : null}
        class:list={["btn-card overflow-hidden rounded-lg text-[var(--primary)] w-11 h-11",
            {"disabled": page.url.prev == undefined}
        ]}
@@ -73,7 +73,7 @@ const getPageUrl = (p: number) => {
             >{p}</a>
         })}
     </div>
-    <a href={url(page.url.next || "")} aria-label={page.url.next ? "Next Page" : null}
+    <a href={page.url.next || ""} aria-label={page.url.next ? "Next Page" : null}
        class:list={["btn-card overflow-hidden rounded-lg text-[var(--primary)] w-11 h-11",
            {"disabled": page.url.next == undefined}
        ]}


### PR DESCRIPTION
Modifying the base configuration in the current project will cause the pagination component to be unable to use the previous and next pages. This is because astro carries the base path by default.

https://github.com/withastro/astro/issues/10358

I modified this and tested paths like "", "/", "xxx" and "xxx/xxxx/"