### PR TITLE
fix: execute customElements.define multiple times at runtime

### DIFF
--- a/src/components/widget/TOC.astro
+++ b/src/components/widget/TOC.astro
@@ -256,6 +256,8 @@ class TableOfContents extends HTMLElement {
     };
 }
 
-customElements.define("table-of-contents", TableOfContents);
+if (!customElements.get('table-of-contents')) {
+    customElements.define("table-of-contents", TableOfContents);
+}
 
 </script>

--- a/src/components/widget/WidgetLayout.astro
+++ b/src/components/widget/WidgetLayout.astro
@@ -53,6 +53,8 @@ const className = Astro.props.class
             })
         }
     }
-
-    customElements.define('widget-layout', WidgetLayout);
+    
+    if (!customElements.get('widget-layout')) {
+        customElements.define('widget-layout', WidgetLayout);
+    }
 </script>


### PR DESCRIPTION
Since swup is used in the project, the code of running the project customElements will be executed multiple times after building.

Added a check to see if customElements has been defined.