### PR TITLE
fix: change deprecated --apply flag to --write

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type-check": "tsc --noEmit --isolatedDeclarations",
     "new-post": "node scripts/new-post.js",
     "format": "biome format --write ./src",
-    "lint": "biome check --apply ./src",
+    "lint": "biome check --write ./src",
     "preinstall": "npx only-allow pnpm"
   },
   "dependencies": {


### PR DESCRIPTION
If you run lint on current main you will get at the top:
```
internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ⚠ The argument --apply is deprecated, it will be removed in the next major release. Use --write instead.
```