### PR TITLE
style: The search panel exceeds the entire page

### DIFF
--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -123,4 +123,8 @@ top-20 left-4 md:left-[unset] right-4 shadow-2xl rounded-2xl p-2">
   input:focus {
     outline: 0;
   }
+  .search-panel {
+    max-height: calc(100vh - 100px);
+    overflow-y: auto;
+  }
 </style>


### PR DESCRIPTION
Add a maximum height for the current query panel

before:
![image](https://github.com/user-attachments/assets/5b44534e-b054-4f2b-95d6-75a91749d04d)
after:
![image](https://github.com/user-attachments/assets/3cf612eb-675a-49bd-a464-fdce255e2ed5)