### PR TITLE
fix: multiple registration events lead to incorrect click events

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -74,29 +74,29 @@ function switchTheme() {
 function loadButtonScript() {
     let switchBtn = document.getElementById("scheme-switch");
     if (switchBtn) {
-        switchBtn.addEventListener("click", function () {
+        switchBtn.onclick = function () {
             switchTheme()
-        });
+        };
     }
 
     let settingBtn = document.getElementById("display-settings-switch");
     if (settingBtn) {
-        settingBtn.addEventListener("click", function () {
+        settingBtn.onclick = function () {
             let settingPanel = document.getElementById("display-setting");
             if (settingPanel) {
                 settingPanel.classList.toggle("float-panel-closed");
             }
-        });
+        };
     }
 
     let menuBtn = document.getElementById("nav-menu-switch");
     if (menuBtn) {
-        menuBtn.addEventListener("click", function () {
+        menuBtn.onclick = function () {
             let menuPanel = document.getElementById("nav-menu-panel");
             if (menuPanel) {
                 menuPanel.classList.toggle("float-panel-closed");
             }
-        });
+        };
     }
 }
 


### PR DESCRIPTION
A click event is added every time the page is jumped. When the page jumps an even number of times, the mobile terminal cannot display the float-panel.
```js
menuPanel.classList.toggle("float-panel-closed");
```
Multiple registration events lead to incorrect click events, which should be caused by swup.
![image](https://github.com/user-attachments/assets/f1d3b7b8-2f65-4acd-9a34-3c1264caa5da)
