### PR TITLE
feat: exclude Katex elements from Pagefind indexing

### DIFF
--- a/pagefind.yml
+++ b/pagefind.yml
@@ -1,0 +1,3 @@
+exclude_selectors:
+  - "span.katex"
+  - "span.katex-display"


### PR DESCRIPTION
In the current Pagefind configuration, mathematical equations are indexed.
As the number of equations increases, excessive Katex syntax appears in search results, which is mostly meaningless.
To reduce build time, I have excluded this syntax from indexing.
