### PR TITLE
fix: prevent scrollbar appearance on single-line tall equations

### DIFF
--- a/src/content/posts/markdown.md
+++ b/src/content/posts/markdown.md
@@ -171,5 +171,12 @@ $$
 \end{equation*}
 $$
 
+$$
+\begin{equation*}
+\pi
+=3+\frac{1^{2}}{6+\frac{3^{2}}{6+\frac{5^{2}}{6+\frac{7^{2}}{6+\frac{9^{2}}{6+\frac{11^{2}}{\ddots}}}}}}
+\end{equation*}
+$$
+
 And note that you can backslash-escape any punctuation characters
 which you wish to be displayed literally, ex.: \`foo\`, \*bar\*, etc.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -319,6 +319,9 @@ function initCustomScrollbar() {
 	const katexElements = document.querySelectorAll('.katex-display') as NodeListOf<HTMLElement>;
 	katexElements.forEach((ele) => {
 		OverlayScrollbars(ele, {
+			overflow: {
+				y: 'hidden',
+			},
 			scrollbars: {
 				theme: 'scrollbar-base scrollbar-auto py-1',
 			}


### PR DESCRIPTION
Normally, displaying tall single-line equations does not cause them to get cut off, but under the current styles, unnecessary scrollbars still appear.

For example:

$$
\frac{p}{q}
$$

$$
\pi
=3+\frac{1^{2}}{6+\frac{3^{2}}{6+\frac{5^{2}}{6+\frac{7^{2}}{6+\frac{9^{2}}{6+\frac{11^{2}}{\ddots}}}}}}
$$

This pull request removes unnecessary vertical scrollbars.
