### PR TITLE
feat: add views counter post

### DIFF
--- a/src/components/PageViews.astro
+++ b/src/components/PageViews.astro
@@ -1,0 +1,109 @@
+---
+
+export interface Props {
+  url: string;
+  language: string;
+}
+const { url = "", language = "" } = Astro.props;
+
+const encodedUrl = encodeURIComponent(url);
+const counterUrl = `https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=${encodedUrl}&count_bg=%234E763000&title_bg=%237A464600&icon=&icon_color=%23E7E7E7&title=Reads+%28Today+%2F+All+Time%29+%3A&edge_flat=true`;
+---
+
+<div class="flex gap-1 opacity-80">
+  <span id="views-count" class="inline-flex items-end">
+    <span class="loading-dot">.</span>
+    <span class="loading-dot">.</span>
+    <span class="loading-dot">.</span>
+  </span>
+  <div class="text-sm"> {language}</div>
+</div>
+
+<style>
+  @keyframes loadingDots {
+    0% {
+      opacity: 0.2;
+    }
+    20% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0.2;
+    }
+  }
+
+  .loading-dot {
+    animation: loadingDots 1.4s infinite;
+    animation-fill-mode: both;
+  }
+
+  .loading-dot:nth-child(2) {
+    animation-delay: 0.2s;
+  }
+
+  .loading-dot:nth-child(3) {
+    animation-delay: 0.4s;
+  }
+</style>
+
+<script define:vars={{ counterUrl }}>
+  function animateNumber(start, end, duration, element) {
+    const startTime = performance.now();
+    const startNumber = parseInt(start);
+    const targetNumber = parseInt(end);
+    const difference = targetNumber - startNumber;
+
+    function easeOutCubic(t) {
+      return 1 - Math.pow(1 - t, 3);
+    }
+
+    function update(currentTime) {
+      const elapsed = currentTime - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+
+      const easedProgress = easeOutCubic(progress);
+      const currentNumber = Math.round(startNumber + (difference * easedProgress));
+
+      // Format number with commas for better readability
+      element.textContent = currentNumber.toLocaleString();
+
+      if (progress < 1) {
+        requestAnimationFrame(update);
+      }
+    }
+
+    requestAnimationFrame(update);
+  }
+
+  async function fetchWithProxy(targetUrl) {
+    const proxyUrl = "https://corsproxy.io/?" + encodeURIComponent(targetUrl);
+    const response = await fetch(proxyUrl);
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    return response.text();
+  }
+
+  async function updateViewCount() {
+    const viewsCount = document.getElementById("views-count");
+    if (!viewsCount) return;
+
+    try {
+      const svgText = await fetchWithProxy(counterUrl);
+      const match = svgText.match(
+        /<text[^>]*fill="#fff"[^>]*>([\d\s/]+)<\/text>/
+      );
+
+      if (match && match[1]) {
+        const count = match[1].trim();
+        const totalViews = count.split("/")[1].trim();
+        viewsCount.textContent = "0"; // Start from zero
+        animateNumber(0, totalViews, 1000, viewsCount); // Animate to actual count over 1 second
+      } else {
+        viewsCount.textContent = "N/A";
+      }
+    } catch {
+      viewsCount.textContent = "N/A";
+    }
+  }
+
+  updateViewCount();
+</script>

--- a/src/i18n/i18nKey.ts
+++ b/src/i18n/i18nKey.ts
@@ -20,6 +20,8 @@ enum I18nKey {
   minutesCount = 'minutesCount',
   postCount = 'postCount',
   postsCount = 'postsCount',
+  viewCount = 'viewCount',
+  viewsCount = 'viewsCount',
 
   themeColor = 'themeColor',
 

--- a/src/i18n/languages/en.ts
+++ b/src/i18n/languages/en.ts
@@ -23,6 +23,8 @@ export const en: Translation = {
   [Key.minutesCount]: 'minutes',
   [Key.postCount]: 'post',
   [Key.postsCount]: 'posts',
+  [Key.viewCount]: 'views',
+  [Key.viewsCount]: 'views',
 
   [Key.themeColor]: 'Theme Color',
 

--- a/src/i18n/languages/es.ts
+++ b/src/i18n/languages/es.ts
@@ -23,6 +23,8 @@ export const es: Translation = {
   [Key.minutesCount]: 'minutos',
   [Key.postCount]: 'publicación',
   [Key.postsCount]: 'publicaciones',
+  [Key.viewCount]: 'views',
+  [Key.viewsCount]: 'views',
 
   [Key.themeColor]: 'Color del tema',
 

--- a/src/i18n/languages/ja.ts
+++ b/src/i18n/languages/ja.ts
@@ -23,6 +23,8 @@ export const ja: Translation = {
   [Key.minutesCount]: '分',
   [Key.postCount]: '件の投稿',
   [Key.postsCount]: '件の投稿',
+  [Key.viewCount]: 'views',
+  [Key.viewsCount]: 'views',
 
   [Key.themeColor]: 'テーマカラー',
 

--- a/src/i18n/languages/ko.ts
+++ b/src/i18n/languages/ko.ts
@@ -23,6 +23,8 @@ export const ko: Translation = {
   [Key.minutesCount]: '분',
   [Key.postCount]: '게시물',
   [Key.postsCount]: '게시물',
+  [Key.viewCount]: 'views',
+  [Key.viewsCount]: 'views',
 
   [Key.themeColor]: '테마 색상',
 

--- a/src/i18n/languages/th.ts
+++ b/src/i18n/languages/th.ts
@@ -23,6 +23,8 @@ export const th: Translation = {
   [Key.minutesCount]: 'นาที',
   [Key.postCount]: 'โพสต์',
   [Key.postsCount]: 'โพสต์',
+  [Key.viewCount]: 'views',
+  [Key.viewsCount]: 'views',
 
   [Key.themeColor]: 'สีของธีม',
 

--- a/src/i18n/languages/zh_CN.ts
+++ b/src/i18n/languages/zh_CN.ts
@@ -23,6 +23,8 @@ export const zh_CN: Translation = {
   [Key.minutesCount]: '分钟',
   [Key.postCount]: '篇文章',
   [Key.postsCount]: '篇文章',
+  [Key.viewCount]: 'views',
+  [Key.viewsCount]: 'views',
 
   [Key.themeColor]: '主题色',
 

--- a/src/i18n/languages/zh_TW.ts
+++ b/src/i18n/languages/zh_TW.ts
@@ -23,6 +23,8 @@ export const zh_TW: Translation = {
   [Key.minutesCount]: '分鐘',
   [Key.postCount]: '篇文章',
   [Key.postsCount]: '篇文章',
+  [Key.viewCount]: 'views',
+  [Key.viewsCount]: 'views',
 
   [Key.themeColor]: '主題色',
 

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -13,6 +13,7 @@ import PostMetadata from '../../components/PostMeta.astro'
 import ImageWrapper from '../../components/misc/ImageWrapper.astro'
 import { profileConfig, siteConfig } from '../../config'
 import { formatDateToYYYYMMDD } from '../../utils/date-utils'
+import PageViews from "@components/PageViews.astro";
 
 export async function getStaticPaths() {
   const blogEntries = await getCollection('posts', ({ data }) => {
@@ -28,6 +29,9 @@ const { entry } = Astro.props
 const { Content, headings } = await entry.render()
 
 const { remarkPluginFrontmatter } = await entry.render()
+
+// Views counter
+const pageUrl = new URL(Astro.url.pathname, Astro.url.origin).href;
 
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -64,6 +68,12 @@ const jsonLd = {
                         <Icon name="material-symbols:schedule-outline-rounded"></Icon>
                     </div>
                     <div class="text-sm">{remarkPluginFrontmatter.minutes} {" " + i18n(I18nKey.minutesCount)}</div>
+                </div>
+                <div class="flex flex-row items-center">
+                    <div class="transition h-6 w-6 rounded-md bg-black/5 dark:bg-white/10 text-black/50 dark:text-white/50 flex items-center justify-center mr-2">
+                        <Icon name="material-symbols:visibility"></Icon>
+                    </div>
+                    <div class="text-sm"><PageViews url={pageUrl}, language={i18n(I18nKey.viewsCount)}/></div>
                 </div>
             </div>
 


### PR DESCRIPTION
> This is my first collaboration. Any advices to create better **Pull requests** are welcomed

This feature add a static views counter for every post in the blog. They only appeared when you open one of the post. 
Most of the code is from this post: [Add Views Counter to your Astro Blog Posts](https://elazizi.com/posts/add-views-counter-to-your-astro-blog-posts/).

I just modify a little bit of his code to integrate it aside the words and minutes counters (and try to respect the icon system).

I also use the `i18n` to translate the word "views" for every language but, the only one translated is **English**. So, if some people want to help me to use the correct translation for every languages, it would be cool 😎 

You can see the result on the image below:
![image](https://github.com/user-attachments/assets/a50c1b25-b965-4316-a19f-404cea2edd0e)
