### PR TITLE
feat: Add spec Single Pages

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,0 +1,31 @@
+---
+
+import MainGridLayout from '../layouts/MainGridLayout.astro'
+
+import { getEntry } from 'astro:content'
+import Markdown from '@components/misc/Markdown.astro'
+import { getCollection } from 'astro:content';
+
+const { slug } = Astro.params;
+
+const pagePost = await getEntry('spec', slug);
+
+const { Content } = await pagePost.render();
+
+export async function getStaticPaths() {
+  const entries = await getCollection('spec');
+  return entries.map(entry => ({
+    params: { slug: entry.slug },
+  }));
+}
+
+---
+<MainGridLayout title={slug} description={slug}>
+    <div class="flex w-full rounded-[var(--radius-large)] overflow-hidden relative min-h-32">
+        <div class="card-base z-10 px-9 py-6 relative w-full ">
+            <Markdown class="mt-2">
+                <Content />
+            </Markdown>
+        </div>
+    </div>
+</MainGridLayout>


### PR DESCRIPTION
For example

about.md `/about/`
link.md `/link/`

This can add more pages by itself

For compatibility, use `/link`

If you need to deploy on a static hosting site  ，please change to `trailingSlash: 'ignore'`

`/astro.config.mjs`

```
{
  trailingSlash: 'ignore'
}
```

docs  :  https://docs.astro.build/en/reference/configuration-reference/#trailingslash