### PR TITLE
修复edge浏览器代码框选换行符高亮而其他浏览器没有

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,6 +18,7 @@ import { GithubCardComponent } from "./src/plugins/rehype-component-github-card.
 import { parseDirectiveNode } from "./src/plugins/remark-directive-rehype.js";
 import { remarkExcerpt } from "./src/plugins/remark-excerpt.js";
 import { remarkReadingTime } from "./src/plugins/remark-reading-time.mjs";
+import { rehypeWrapperSpan } from "./src/plugins/rehype-wrapper-span.js";
 
 // https://astro.build/config
 export default defineConfig({
@@ -111,6 +112,7 @@ export default defineConfig({
           },
         },
       ],
+      rehypeWrapperSpan,
     ],
   },
   vite: {

--- a/src/plugins/rehype-wrapper-span.js
+++ b/src/plugins/rehype-wrapper-span.js
@@ -1,0 +1,13 @@
+import { visit } from "unist-util-visit";
+import { h } from "hastscript";
+
+export function rehypeWrapperSpan() {
+    return (tree) => {
+        visit(tree, "element", (node, index, parent) => {
+            if (parent?.tagName === "pre" && node.tagName === "code") {
+                node.children = [h("span", node.children)];
+                return visit.SKIP;
+            }
+        });
+    };
+}


### PR DESCRIPTION
在edge浏览器框选代码
会出现换行高亮
![image](https://github.com/user-attachments/assets/0f20eb2f-c0cb-48c2-b34d-785cf0dbb360)
 写了个rehype插件通过在AST树上给<code>{children}</code> 变成<code><span>{children} </span></code>
![image](https://github.com/user-attachments/assets/4ee85983-544b-4fcf-bf6f-f947a3dabe31)
