### PR TITLE
fix: svelte component causing hydration mismatch warning

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -50,7 +50,7 @@ let links: NavBarLink[] = navBarConfig.links.map(
                         <Icon name="material-symbols:palette-outline" class="text-[1.25rem]"></Icon>
                     </button>
             )}
-            <LightDarkSwitch client:load></LightDarkSwitch>
+            <LightDarkSwitch client:only="svelte"></LightDarkSwitch>
             <button aria-label="Menu" name="Nav Menu" class="btn-plain scale-animation rounded-lg w-11 h-11 active:scale-90 md:!hidden" id="nav-menu-switch">
                 <Icon name="material-symbols:menu-rounded" class="text-[1.25rem]"></Icon>
             </button>


### PR DESCRIPTION
In navbar component, the LightDarkSwitch svelte component was used with the incorrect directive. This led to a warning in the console when the app is built and previewed. `client:only="svelte"` must be used to fix this warning.

The documentation for this:
https://docs.astro.build/en/reference/directives-reference/#clientonly