### PR TITLE
fix(blog): restore prev/next post navigation buttons

### DIFF
--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -13,11 +13,10 @@ import PostMetadata from '../../components/PostMeta.astro'
 import ImageWrapper from '../../components/misc/ImageWrapper.astro'
 import { profileConfig, siteConfig } from '../../config'
 import { formatDateToYYYYMMDD } from '../../utils/date-utils'
+import { getSortedPosts } from '@utils/content-utils'
 
 export async function getStaticPaths() {
-  const blogEntries = await getCollection('posts', ({ data }) => {
-    return import.meta.env.PROD ? data.draft !== true : true
-  })
+  const blogEntries = await getSortedPosts();
   return blogEntries.map(entry => ({
     params: { slug: entry.slug },
     props: { entry },

--- a/src/utils/content-utils.ts
+++ b/src/utils/content-utils.ts
@@ -1,17 +1,14 @@
 import { getCollection } from 'astro:content'
-import type { BlogPostData } from '@/types/config'
 import I18nKey from '@i18n/i18nKey'
 import { i18n } from '@i18n/translation'
 
-export async function getSortedPosts(): Promise<
-  { body: string, data: BlogPostData; slug: string }[]
-> {
+export async function getSortedPosts() {
   const allBlogPosts = (await getCollection('posts', ({ data }) => {
     return import.meta.env.PROD ? data.draft !== true : true
-  })) as unknown as { body: string, data: BlogPostData; slug: string }[]
+  }))
 
   const sorted = allBlogPosts.sort(
-    (a: { data: BlogPostData }, b: { data: BlogPostData }) => {
+    (a, b) => {
       const dateA = new Date(a.data.published)
       const dateB = new Date(b.data.published)
       return dateA > dateB ? -1 : 1


### PR DESCRIPTION
BTW, we can delete type declaration, and i don't find any type error here.
![screenshot](https://github.com/user-attachments/assets/4686eaa1-ffba-4534-ae11-7caef345f54e)
