### PR TITLE
fix: biome linter error

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,14 +1,15 @@
 ---
-import path from 'path'
+import path from 'node:path'
+import { Icon } from 'astro-icon/components'
+import I18nKey from '../i18n/i18nKey'
+import { i18n } from '../i18n/translation'
+import { getDir } from '../utils/url-utils'
 import PostMetadata from './PostMeta.astro'
 import ImageWrapper from './misc/ImageWrapper.astro'
-import { Icon } from 'astro-icon/components'
-import { i18n } from '../i18n/translation'
-import I18nKey from '../i18n/i18nKey'
-import { getDir } from '../utils/url-utils'
 
 interface Props {
   class?: string
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   entry: any
   title: string
   url: string

--- a/src/components/control/Pagination.astro
+++ b/src/components/control/Pagination.astro
@@ -19,8 +19,8 @@ const VISIBLE = ADJ_DIST * 2 + 1
 
 // for test
 let count = 1
-let l = page.currentPage,
-  r = page.currentPage
+let l = page.currentPage
+let r = page.currentPage
 while (0 < l - 1 && r + 1 <= page.lastPage && count + 2 <= VISIBLE) {
   count += 2
   l--
@@ -37,15 +37,15 @@ while (r + 1 <= page.lastPage && count < VISIBLE) {
 
 let pages: number[] = []
 if (l > 1) pages.push(1)
-if (l == 3) pages.push(2)
+if (l === 3) pages.push(2)
 if (l > 3) pages.push(HIDDEN)
 for (let i = l; i <= r; i++) pages.push(i)
 if (r < page.lastPage - 2) pages.push(HIDDEN)
-if (r == page.lastPage - 2) pages.push(page.lastPage - 1)
+if (r === page.lastPage - 2) pages.push(page.lastPage - 1)
 if (r < page.lastPage) pages.push(page.lastPage)
 
 const getPageUrl = (p: number) => {
-  if (p == 1) return '/'
+  if (p === 1) return '/'
   return `/${p}/`
 }
 ---

--- a/src/components/misc/ImageWrapper.astro
+++ b/src/components/misc/ImageWrapper.astro
@@ -1,5 +1,5 @@
 ---
-import path from 'path'
+import path from 'node:path'
 interface Props {
   id?: string
   src: string
@@ -24,6 +24,7 @@ const isPublic = src.startsWith('/')
 
 // TODO temporary workaround for images dynamic import
 // https://github.com/withastro/astro/issues/3373
+// biome-ignore lint/suspicious/noImplicitAnyLet: <explanation>
 let img
 if (isLocal) {
   const files = import.meta.glob<ImageMetadata>('../../**', {

--- a/src/components/widget/TOC.astro
+++ b/src/components/widget/TOC.astro
@@ -18,7 +18,7 @@ const className = Astro.props.class
 
 const removeTailingHash = (text: string) => {
     let lastIndexOfHash = text.lastIndexOf('#');
-    if (lastIndexOfHash != text.length - 1) {
+    if (lastIndexOfHash !== text.length - 1) {
         return text;
     }
 

--- a/src/plugins/rehype-component-admonition.mjs
+++ b/src/plugins/rehype-component-admonition.mjs
@@ -19,14 +19,15 @@ export function AdmonitionComponent(properties, children, type) {
     )
 
   let label = null
-  if (properties && properties['has-directive-label']) {
+  if (properties?.['has-directive-label']) {
     label = children[0] // The first child is the label
+    // biome-ignore lint/style/noParameterAssign: <explanation>
     children = children.slice(1)
     label.tagName = 'div' // Change the tag <p> to <div>
   }
 
-  return h(`blockquote`, { class: `admonition bdm-${type}` }, [
-    h('span', { class: `bdm-title` }, label ? label : type.toUpperCase()),
+  return h("blockquote", { class: `admonition bdm-${type}` }, [
+    h('span', { class: "bdm-title" }, label ? label : type.toUpperCase()),
     ...children,
   ])
 }

--- a/src/plugins/rehype-component-github-card.mjs
+++ b/src/plugins/rehype-component-github-card.mjs
@@ -32,7 +32,7 @@ export function GithubCardComponent(properties, children) {
     'Waiting...',
   )
 
-  const nTitle = h(`div`, { class: 'gc-titlebar' }, [
+  const nTitle = h("div", { class: 'gc-titlebar' }, [
     h('div', { class: 'gc-titlebar-left' }, [
       h('div', { class: 'gc-owner' }, [
         nAvatar,

--- a/src/plugins/remark-directive-rehype.js
+++ b/src/plugins/remark-directive-rehype.js
@@ -1,4 +1,3 @@
-// biome-ignore lint/suspicious/noShadowRestrictedNames: <explanation>
 import { h } from 'hastscript'
 import { visit } from 'unist-util-visit'
 
@@ -10,6 +9,7 @@ export function parseDirectiveNode() {
         node.type === 'leafDirective' ||
         node.type === 'textDirective'
       ) {
+        // biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
         const data = node.data || (node.data = {})
         node.attributes = node.attributes || {}
         if (

--- a/src/plugins/remark-excerpt.js
+++ b/src/plugins/remark-excerpt.js
@@ -1,10 +1,11 @@
+// biome-ignore lint/suspicious/noShadowRestrictedNames: <explanation>
 import { toString } from 'mdast-util-to-string'
 
 /* Use the post's first paragraph as the excerpt */
 export function remarkExcerpt() {
   return (tree, { data }) => {
     let excerpt = ''
-    for (let node of tree.children) {
+    for (const node of tree.children) {
       if (node.type !== 'paragraph') {
         continue
       }


### PR DESCRIPTION
This pull request includes several changes to improve code consistency, correct syntax, and add comments to ignore specific linting rules. The changes affect multiple files across the project.

### Code Consistency and Syntax Corrections:

* [`src/components/control/Pagination.astro`](diffhunk://#diff-8ffe2a069ccb1bd73de30b3e7fd8f5f269b1973704ff1f062802540bb6f833cbL40-R48): Corrected equality checks from `==` to `===` and adjusted code formatting for better readability. [[1]](diffhunk://#diff-8ffe2a069ccb1bd73de30b3e7fd8f5f269b1973704ff1f062802540bb6f833cbL40-R48) [[2]](diffhunk://#diff-8ffe2a069ccb1bd73de30b3e7fd8f5f269b1973704ff1f062802540bb6f833cbL22-R23)
* [`src/components/widget/TOC.astro`](diffhunk://#diff-7f89d17674c4659b071e362b6966e1841d4d15532caed6f3c8bc730c7dc490dcL21-R21): Changed equality check from `!=` to `!==` for better type safety.
* [`src/plugins/rehype-component-admonition.mjs`](diffhunk://#diff-05f6c2c5273f5b2df44a91f7c7fc6bbc5981ed39ee287a5a58505e140f5ab76aL22-R30): Added optional chaining and corrected string quotes for consistency.
* [`src/plugins/rehype-component-github-card.mjs`](diffhunk://#diff-ada3e33098ac2850620d0917744a12151d6dec6f632e1cddb92a6a4d26b0f429L35-R35): Changed string quotes for consistency.

### Linting Rule Comments:

* [`src/components/PostCard.astro`](diffhunk://#diff-4498ff96dd152c425ae39e667ed9f369256259ea9d26bc791d85d0a2e68a6ef4L2-R12): Added comments to ignore specific linting rules for explicit `any` type.
* [`src/components/misc/ImageWrapper.astro`](diffhunk://#diff-ce7555baf3c74c9f7a3e9fdda3fb089d21ca9048cdd13569f3edd76adacc2cc3R27): Added comments to ignore specific linting rules for implicit `any` type.
* [`src/plugins/remark-directive-rehype.js`](diffhunk://#diff-bc054476893dbba703997c7e16b0c3b5ee78d2db7fc66d1ea5fe7f80b87620dcR12): Added comments to ignore specific linting rules for assignment in expressions and shadowing restricted names. [[1]](diffhunk://#diff-bc054476893dbba703997c7e16b0c3b5ee78d2db7fc66d1ea5fe7f80b87620dcR12) [[2]](diffhunk://#diff-bc054476893dbba703997c7e16b0c3b5ee78d2db7fc66d1ea5fe7f80b87620dcL1)
* [`src/plugins/remark-excerpt.js`](diffhunk://#diff-bee0c013d8b9304b5916fc372652704341837a44eeaf99a5a2093f01af7780bbR1-R8): Added comments to ignore specific linting rules for shadowing restricted names.