### PR TITLE
refactor: fix astro check error

### DIFF
--- a/src/components/ArchivePanel.astro
+++ b/src/components/ArchivePanel.astro
@@ -10,7 +10,7 @@ interface Props {
   tags?: string[]
   categories?: string[]
 }
-const { keyword, tags, categories } = Astro.props
+const { tags, categories } = Astro.props
 
 let posts = await getSortedPosts()
 

--- a/src/components/control/ButtonTag.astro
+++ b/src/components/control/ButtonTag.astro
@@ -5,7 +5,7 @@ interface Props {
   href?: string
   label?: string
 }
-const { size, dot, href, label }: Props = Astro.props
+const { dot, href, label }: Props = Astro.props
 ---
 <a href={href} aria-label={label} class="btn-regular h-8 text-sm px-3 rounded-lg">
     {dot && <div class="h-1 w-1 bg-[var(--btn-content)] dark:bg-[var(--card-bg)] transition rounded-md mr-2"></div>}

--- a/src/components/misc/License.astro
+++ b/src/components/misc/License.astro
@@ -12,7 +12,7 @@ interface Props {
   class: string
 }
 
-const { title, slug, pubDate } = Astro.props
+const { title, pubDate } = Astro.props
 const className = Astro.props.class
 const profileConf = profileConfig
 const licenseConf = licenseConfig

--- a/src/components/widget/SideBar.astro
+++ b/src/components/widget/SideBar.astro
@@ -3,7 +3,6 @@ import Profile from './Profile.astro'
 import Tag from './Tags.astro'
 import Categories from './Categories.astro'
 import type { MarkdownHeading } from 'astro'
-import TOC from './TOC.astro'
 
 interface Props {
     class? : string
@@ -11,7 +10,6 @@ interface Props {
 }
 
 const className = Astro.props.class
-const headings = Astro.props.headings
 
 ---
 <div id="sidebar" class:list={[className, "w-full"]}>

--- a/src/components/widget/WidgetLayout.astro
+++ b/src/components/widget/WidgetLayout.astro
@@ -10,7 +10,6 @@ interface Props {
   class?: string
   style?: string
 }
-const props = Astro.props
 const { id, name, isCollapsed, collapsedHeight, style } = Astro.props
 const className = Astro.props.class
 ---

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -208,9 +208,7 @@ import {
 	BANNER_HEIGHT,
 	BANNER_HEIGHT_HOME,
 	BANNER_HEIGHT_EXTEND,
-	MAIN_PANEL_OVERLAPS_BANNER_HEIGHT,
-	PAGE_WIDTH
-} from "../constants/constants";
+	MAIN_PANEL_OVERLAPS_BANNER_HEIGHT} from "../constants/constants";
 
 /* Preload fonts */
 // (async function() {
@@ -405,7 +403,7 @@ const setup = () => {
 			heightExtend.classList.remove('hidden')
 		}
 	});
-	window.swup.hooks.on('visit:end', (visit: {to: {url: string}}) => {
+	window.swup.hooks.on('visit:end', (_visit: {to: {url: string}}) => {
 		setTimeout(() => {
 			const heightExtend = document.getElementById('page-height-extend')
 			if (heightExtend) {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,10 +6,15 @@ import { getEntry } from 'astro:content'
 import { i18n } from '../i18n/translation'
 import I18nKey from '../i18n/i18nKey'
 import Markdown from '@components/misc/Markdown.astro'
+import { render } from 'astro:content'
 
 const aboutPost = await getEntry('spec', 'about')
 
-const { Content } = await aboutPost.render()
+if (!aboutPost) {
+  throw new Error("About page content not found");
+}
+
+const { Content } = await render(aboutPost)
 ---
 <MainGridLayout title={i18n(I18nKey.about)} description={i18n(I18nKey.about)}>
     <div class="flex w-full rounded-[var(--radius-large)] overflow-hidden relative min-h-32">

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -1,6 +1,5 @@
 ---
 import path from 'node:path'
-import { getCollection } from 'astro:content'
 import License from '@components/misc/License.astro'
 import Markdown from '@components/misc/Markdown.astro'
 import I18nKey from '@i18n/i18nKey'


### PR DESCRIPTION
This pull request includes several changes across multiple files to clean up and improve the codebase. The most important changes involve removing unused variables and imports, handling errors, and updating component properties.

### Codebase cleanup and simplification:

* [`src/components/ArchivePanel.astro`](diffhunk://#diff-bcc4599d084b71bb46b6402ca48b8323655473730264db4de8831f3b7f65c079L13-R13): Removed the unused `keyword` property from the `Astro.props` destructuring.
* [`src/components/control/ButtonTag.astro`](diffhunk://#diff-65f2db5e6b8014bac09f07aed0b6227ae6173731e2df2b0c5d00f91290e9d4ffL8-R8): Removed the unused `size` property from the `Astro.props` destructuring.
* [`src/components/misc/License.astro`](diffhunk://#diff-0301418fd9c92a4d3ae23056058a9cd33849684b34b4f038d9d7d6bb88039d54L15-R15): Removed the unused `slug` property from the `Astro.props` destructuring.
* [`src/components/widget/SideBar.astro`](diffhunk://#diff-6cae2a8052dc7167ff394d91985feb1a78d4d71256625e0310faf7a44356011aL6-L14): Removed the unused `TOC` import and the `headings` property from the `Astro.props` destructuring.
* [`src/components/widget/WidgetLayout.astro`](diffhunk://#diff-0703a25ad15afd642d1793bfdf83cd70e51bbe6913ae2561ed2d57fb7917c478L13): Removed the unused `props` variable.

### Error handling improvement:

* [`src/pages/about.astro`](diffhunk://#diff-cb33463363c150558e340277672bb5c583640ddb38012f53a33ed69125d92038R9-R17): Added error handling for missing `aboutPost` content and used the `render` function from `astro:content` to render the content.

### Import optimization:

* [`src/layouts/Layout.astro`](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L211-R211): Removed unused constants `PAGE_WIDTH` from the import statement.
* `src/pages/posts/[...slug].astro`: Removed the unused `getCollection` import. ([src/pages/posts/[...slug].astroL3](diffhunk://#diff-a0632c780ca4d8a863918371cb04c1cae536002ac7ec77209d237003bc41c104L3))

### Code readability:

* [`src/layouts/Layout.astro`](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L408-R406): Updated the `visit:end` hook callback parameter to use `_visit` to indicate the parameter is unused.