### PR TITLE
refactor: replace 'any' type with CollectionEntry

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,5 +1,6 @@
 ---
 import path from "node:path";
+import type { CollectionEntry } from "astro:content";
 import { Icon } from "astro-icon/components";
 import I18nKey from "../i18n/i18nKey";
 import { i18n } from "../i18n/translation";
@@ -9,8 +10,7 @@ import ImageWrapper from "./misc/ImageWrapper.astro";
 
 interface Props {
 	class?: string;
-	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
-	entry: any;
+	entry: CollectionEntry<"posts">;
 	title: string;
 	url: string;
 	published: Date;

--- a/src/components/PostPage.astro
+++ b/src/components/PostPage.astro
@@ -1,4 +1,5 @@
 ---
+import type { CollectionEntry } from "astro:content";
 import { getPostUrlBySlug } from "@utils/url-utils";
 import PostCard from "./PostCard.astro";
 
@@ -8,22 +9,20 @@ let delay = 0;
 const interval = 50;
 ---
 <div class="transition flex flex-col rounded-[var(--radius-large)] bg-[var(--card-bg)] py-1 md:py-0 md:bg-transparent md:gap-4 mb-4">
-    {page.data.map((entry: { data: { draft: boolean; title: string; tags: string[]; category: string; published: Date; image: string; description: string; updated: Date; }; slug: string; }) => {
-        return (
-            <PostCard
-                    entry={entry}
-                    title={entry.data.title}
-                    tags={entry.data.tags}
-                    category={entry.data.category}
-                    published={entry.data.published}
-                    updated={entry.data.updated}
-                    url={getPostUrlBySlug(entry.slug)}
-                    image={entry.data.image}
-                    description={entry.data.description}
-                    draft={entry.data.draft}
-                    class:list="onload-animation"
-                    style={`animation-delay: calc(var(--content-delay) + ${delay++ * interval}ms);`}
-            ></PostCard>
-        );
-    })}
+    {page.data.map((entry: CollectionEntry<"posts">) => (
+        <PostCard
+                entry={entry}
+                title={entry.data.title}
+                tags={entry.data.tags}
+                category={entry.data.category}
+                published={entry.data.published}
+                updated={entry.data.updated}
+                url={getPostUrlBySlug(entry.slug)}
+                image={entry.data.image}
+                description={entry.data.description}
+                draft={entry.data.draft}
+                class:list="onload-animation"
+                style={`animation-delay: calc(var(--content-delay) + ${delay++ * interval}ms);`}
+        ></PostCard>
+    ))}
 </div>


### PR DESCRIPTION
This pull request includes changes to the `PostCard` and `PostPage` components to improve type safety by replacing the `any` type with the `CollectionEntry` type from `astro:content`.

Improvements to type safety:

* [`src/components/PostCard.astro`](diffhunk://#diff-4498ff96dd152c425ae39e667ed9f369256259ea9d26bc791d85d0a2e68a6ef4R3): Imported `CollectionEntry` from `astro:content` and updated the `entry` prop type to `CollectionEntry<"posts">`. [[1]](diffhunk://#diff-4498ff96dd152c425ae39e667ed9f369256259ea9d26bc791d85d0a2e68a6ef4R3) [[2]](diffhunk://#diff-4498ff96dd152c425ae39e667ed9f369256259ea9d26bc791d85d0a2e68a6ef4L12-R13)
* [`src/components/PostPage.astro`](diffhunk://#diff-25fd4f9a2e0a43e96904f8eca5f7e5d8f96036ad3d21c623ddf6ca0b3c6064a9R2): Imported `CollectionEntry` from `astro:content` and updated the type of `entry` in the `page.data.map` function to `CollectionEntry<"posts">`. [[1]](diffhunk://#diff-25fd4f9a2e0a43e96904f8eca5f7e5d8f96036ad3d21c623ddf6ca0b3c6064a9R2) [[2]](diffhunk://#diff-25fd4f9a2e0a43e96904f8eca5f7e5d8f96036ad3d21c623ddf6ca0b3c6064a9L11-R12) [[3]](diffhunk://#diff-25fd4f9a2e0a43e96904f8eca5f7e5d8f96036ad3d21c623ddf6ca0b3c6064a9L27-R27)