### PR TITLE
chore: change Twitter icon and URL to X

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -57,11 +57,11 @@ export const profileConfig: ProfileConfig = {
 	bio: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
 	links: [
 		{
-			name: "Twitter",
-			icon: "fa6-brands:twitter", // Visit https://icones.js.org/ for icon codes
+			name: "X",
+			icon: "fa6-brands:x-twitter", // Visit https://icones.js.org/ for icon codes
 			// You will need to install the corresponding icon set if it's not already included
 			// `pnpm add @iconify-json/<icon-set-name>`
-			url: "https://twitter.com",
+			url: "https://x.com",
 		},
 		{
 			name: "Steam",


### PR DESCRIPTION
#394
- Replaced Twitter icon with X icon
- Updated URLs from `twitter.com` to `x.com`