### PR TITLE
Feature waline comments

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -80,3 +80,8 @@ export const licenseConfig: LicenseConfig = {
   name: 'CC BY-NC-SA 4.0',
   url: 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
 }
+
+export const walineConfig = {
+  serverURL: '',
+  login: 'force',
+}

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -6,6 +6,7 @@ const postsCollection = defineCollection({
     published: z.date(),
     updated: z.date().optional(),
     draft: z.boolean().optional().default(false),
+    comments: z.boolean().optional().default(false),
     description: z.string().optional().default(''),
     image: z.string().optional().default(''),
     tags: z.array(z.string()).optional().default([]),

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -146,6 +146,7 @@ const bannerOffset =
 		<slot name="head"></slot>
 
 		<link rel="alternate" type="application/rss+xml" title={profileConfig.name} href={`${Astro.site}rss.xml`}/>
+		<link rel="stylesheet" href="https://unpkg.com/@waline/client@v3/dist/waline.css" />
 
 	</head>
 	<body class=" min-h-screen transition " class:list={[{"lg:is-home": isHomePage, "enable-banner": enableBanner}]}

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -6,14 +6,15 @@ import Markdown from '@components/misc/Markdown.astro'
 import I18nKey from '@i18n/i18nKey'
 import { i18n } from '@i18n/translation'
 import MainGridLayout from '@layouts/MainGridLayout.astro'
+import { getSortedPosts } from '@utils/content-utils'
 import { getDir, getPostUrlBySlug } from '@utils/url-utils'
 import { Icon } from 'astro-icon/components'
 import { licenseConfig } from 'src/config'
+import { walineConfig } from 'src/config'
 import PostMetadata from '../../components/PostMeta.astro'
 import ImageWrapper from '../../components/misc/ImageWrapper.astro'
 import { profileConfig, siteConfig } from '../../config'
 import { formatDateToYYYYMMDD } from '../../utils/date-utils'
-import { getSortedPosts } from '@utils/content-utils'
 
 export async function getStaticPaths() {
   const blogEntries = await getSortedPosts();
@@ -105,6 +106,22 @@ const jsonLd = {
 
             {licenseConfig.enable && <License title={entry.data.title} slug={entry.slug} pubDate={entry.data.published} class="mb-6 rounded-xl license-container onload-animation"></License>}
 
+            <!-- Waline -->
+            {entry.data.comments !== false && (
+                <>
+                    <link rel="stylesheet" href="https://unpkg.com/@waline/client@v3/dist/waline.css" />
+                    <div id="waline" class="mb-8" />
+                    <script type="module" is:inline define:vars={{ walineConfig }}>
+                    import { init } from 'https://unpkg.com/@waline/client@v3/dist/waline.js';
+                    init({
+                        el: '#waline',
+                        serverURL: walineConfig.serverURL,
+                        login: walineConfig.login,
+                        path: location.pathname,
+                    });
+                    </script>
+                </>
+            )}
         </div>
     </div>
 

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -105,25 +105,30 @@ const jsonLd = {
             </Markdown>
 
             {licenseConfig.enable && <License title={entry.data.title} slug={entry.slug} pubDate={entry.data.published} class="mb-6 rounded-xl license-container onload-animation"></License>}
-
-            <!-- Waline -->
-            {entry.data.comments !== false && (
-                <>
-                    <link rel="stylesheet" href="https://unpkg.com/@waline/client@v3/dist/waline.css" />
-                    <div id="waline" class="mb-8" />
-                    <script type="module" is:inline define:vars={{ walineConfig }}>
-                    import { init } from 'https://unpkg.com/@waline/client@v3/dist/waline.js';
-                    init({
-                        el: '#waline',
-                        serverURL: walineConfig.serverURL,
-                        login: walineConfig.login,
-                        path: location.pathname,
-                    });
-                    </script>
-                </>
-            )}
+            
         </div>
     </div>
+
+    <!-- Waline -->
+    {entry.data.comments !== false && (
+        <div class="card-base z-10 px-6 md:px-9 pt-6 pb-4 relative w-full mb-4">
+            <div id="waline" />
+            <script type="module" is:inline define:vars={{ walineConfig }}>
+            import { init } from 'https://unpkg.com/@waline/client@v3/dist/waline.js';
+            function loadWaline() {
+                init({
+                    el: '#waline',
+                    serverURL: walineConfig.serverURL,
+                    login: walineConfig.login,
+                    path: location.pathname,
+                    wordLimit: ["2", "1000"],
+                    dark: '.dark',
+                });
+            }
+            loadWaline();
+            </script>
+        </div>
+    )}
 
     <div class="flex flex-col md:flex-row justify-between mb-4 gap-4 overflow-hidden w-full">
         <a href={entry.data.nextSlug ? getPostUrlBySlug(entry.data.nextSlug) : "#"}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -79,6 +79,7 @@ export type BlogPostData = {
   description: string
   tags: string[]
   draft?: boolean
+  comments?: boolean
   image?: string
   category?: string
   prevTitle?: string


### PR DESCRIPTION
![企业微信截图_20250417155654](https://github.com/user-attachments/assets/3ff244e8-049f-4437-960a-3bcfe349a8cc)
![image](https://github.com/user-attachments/assets/ba22a2fb-a155-413a-9a8b-25b8cf76d808)

添加了waline评论：
需要在[官方文档](https://waline.js.org/guide/get-started/)中根据官方文档操作，完成waline的部署。
最后在`src/config.ts`中添入`serverURL`配置项（部署好的waline地址），在文章的`Front-matter`中加入`comments: true`即可在单篇文章中启用waline评论。
需要的话我之后可以补充详细的操作步骤。

Added Waline comments:
You need to follow the instructions in the [official documentation](https://waline.js.org/guide/get-started/) to complete the Waline deployment. 
Finally, add the `serverURL` configuration item (the deployed Waline address) in `src/config.ts`, and include `comments: true` in the article's `Front-matter` to enable Waline comments for individual posts.
If needed, I can provide more detailed operation steps later."