### PR TITLE
fix: enhance link styling on hover and active states

### DIFF
--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -22,9 +22,14 @@
     a:not(.no-styling) {
         @apply relative bg-none link font-medium text-[var(--primary)]
         underline decoration-[var(--link-underline)] decoration-1 decoration-dashed underline-offset-4;
-
+        box-decoration-break: clone;
+        -webkit-box-decoration-break: clone;
+    
         &:hover, &:active {
             @apply decoration-transparent;
+            background: var(--btn-plain-bg-hover);
+            border-bottom: 1px dashed var(--link-hover);
+            text-decoration: none;
         }
     }
 


### PR DESCRIPTION
This pull request makes a small enhancement to the styling of links in the `src/styles/markdown.css` file. The changes improve the appearance and behavior of links, particularly when they span multiple lines or are hovered over.

Styling improvements:

* Added `box-decoration-break: clone` and `-webkit-box-decoration-break: clone` to ensure proper styling of links that span multiple lines.
* Updated hover and active states to include a background color (`var(--btn-plain-bg-hover)`), a dashed border-bottom (`var(--link-hover)`), and removed text decoration for a cleaner hover effect.

close #412 