### PR TITLE
fix: Encode URI components for tag links to handle reserved characters

### DIFF
--- a/src/components/PostMeta.astro
+++ b/src/components/PostMeta.astro
@@ -70,7 +70,7 @@ const className = Astro.props.class;
         <div class="flex flex-row flex-nowrap items-center">
             {(tags && tags.length > 0) && tags.map((tag, i) => (
                 <div class:list={[{"hidden": i == 0}, "mx-1.5 text-[var(--meta-divider)] text-sm"]}>/</div>
-                <a href={url(`/archive/tag/${tag}/`)} aria-label=`View all posts with the ${tag} tag`
+                <a href={url(`/archive/tag/${encodeURIComponent(tag)}/`)} aria-label=`View all posts with the ${tag} tag`
                    class="link-lg transition text-50 text-sm font-medium
                                 hover:text-[var(--primary)] dark:hover:text-[var(--primary)] whitespace-nowrap">
                     {tag}

--- a/src/components/widget/Tags.astro
+++ b/src/components/widget/Tags.astro
@@ -23,7 +23,7 @@ const style = Astro.props.style;
 <WidgetLayout name={i18n(I18nKey.tags)} id="tags" isCollapsed={isCollapsed} collapsedHeight={COLLAPSED_HEIGHT} class={className} style={style}>
     <div class="flex gap-2 flex-wrap">
         {tags.map(t => (
-            <ButtonTag href={url(`/archive/tag/${t.name}/`)} label={`View all posts with the ${t.name} tag`}>
+            <ButtonTag href={url(`/archive/tag/${encodeURIComponent(t.name)}/`)} label={`View all posts with the ${t.name} tag`}>
                 {t.name}
             </ButtonTag>
         ))}

--- a/src/content/posts/reserved-character-test.md
+++ b/src/content/posts/reserved-character-test.md
@@ -1,9 +1,0 @@
----
-title: Reserved Character Test
-published: 2025-05-01
-tags: ["C#", "$fuwari", "#test"]
-category: Examples
-draft: true
----
-
-This page is test for reserved character

--- a/src/content/posts/reserved-character-test.md
+++ b/src/content/posts/reserved-character-test.md
@@ -1,0 +1,9 @@
+---
+title: Reserved Character Test
+published: 2025-05-01
+tags: ["C#", "$fuwari", "#test"]
+category: Examples
+draft: true
+---
+
+This page is test for reserved character

--- a/src/pages/archive/tag/[tag].astro
+++ b/src/pages/archive/tag/[tag].astro
@@ -19,12 +19,12 @@ export async function getStaticPaths() {
 
 	return allTagsArray.map((tag) => ({
 		params: {
-			tag: tag,
+			tag: encodeURIComponent(tag),
 		},
 	}));
 }
 
-const tag = Astro.params.tag as string;
+const tag = decodeURIComponent(Astro.params.tag as string);
 ---
 
 <MainGridLayout title={i18n(I18nKey.archive)} description={i18n(I18nKey.archive)}>


### PR DESCRIPTION
This pull request introduces changes to improve handling of reserved characters in tags across the application. The updates ensure that tags with special characters are properly encoded and decoded, preventing potential issues with URLs and routing. Additionally, a new test post is added to validate these changes.

### Improvements to reserved character handling:

* [`src/components/PostMeta.astro`](diffhunk://#diff-e49ad2b45728c5139fcce0c5b309b5c05e54a89977dada8c726fd5fb313df712L73-R73): Updated the `href` attribute for tag links to use `encodeURIComponent` to properly encode special characters in tag URLs.
* [`src/components/widget/Tags.astro`](diffhunk://#diff-717ccf3787b3f8eb930b9b9598e58a96bdbb0b183d95c9eee0ef3d8550de3284L26-R26): Modified the `href` attribute in `ButtonTag` components to use `encodeURIComponent` for consistent handling of special characters in tag URLs.
* `src/pages/archive/tag/[tag].astro`: Added `encodeURIComponent` when generating static paths for tags and `decodeURIComponent` when reading the tag parameter to ensure proper encoding and decoding of special characters. ([src/pages/archive/tag/[tag].astroL22-R27](diffhunk://#diff-d7e2bb9688cf74b66a4bbe92a5590f7c7bb0e4b6b808c9d3e14bd6d6e3709573L22-R27))