### PR TITLE
Fix category with reserved character

### DIFF
--- a/src/components/PostMeta.astro
+++ b/src/components/PostMeta.astro
@@ -53,7 +53,7 @@ const className = Astro.props.class;
             <Icon name="material-symbols:book-2-outline-rounded" class="text-xl"></Icon>
         </div>
         <div class="flex flex-row flex-nowrap items-center">
-            <a href={url(`/archive/category/${category || 'uncategorized'}/`)} aria-label=`View all posts in the ${category} category`
+            <a href={url(`/archive/category/${encodeURIComponent(category || 'uncategorized')}/`)} aria-label=`View all posts in the ${category} category`
                class="link-lg transition text-50 text-sm font-medium
                             hover:text-[var(--primary)] dark:hover:text-[var(--primary)] whitespace-nowrap">
                 {category || i18n(I18nKey.uncategorized)}

--- a/src/pages/archive/category/[category].astro
+++ b/src/pages/archive/category/[category].astro
@@ -10,13 +10,13 @@ export async function getStaticPaths() {
 	return categories.map((category) => {
 		return {
 			params: {
-				category: category.name,
+				category: encodeURIComponent(category.name),
 			},
 		};
 	});
 }
 
-const category = Astro.params.category as string;
+const category = decodeURIComponent(Astro.params.category as string);
 ---
 
 <MainGridLayout title={i18n(I18nKey.archive)} description={i18n(I18nKey.archive)}>

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -19,7 +19,7 @@ export function getPostUrlBySlug(slug: string): string {
 export function getCategoryUrl(category: string): string {
 	if (category === i18n(i18nKey.uncategorized))
 		return url("/archive/category/uncategorized/");
-	return url(`/archive/category/${category}/`);
+	return url(`/archive/category/${encodeURIComponent(category)}/`);
 }
 
 export function getDir(path: string): string {


### PR DESCRIPTION
This pull request introduces changes to ensure proper encoding and decoding of category names in URLs, improving URL safety and handling special characters. The updates affect components, pages, and utility functions related to category URLs.

### Improvements to URL encoding and decoding:

* [`src/components/PostMeta.astro`](diffhunk://#diff-e49ad2b45728c5139fcce0c5b309b5c05e54a89977dada8c726fd5fb313df712L56-R56): Updated the category link to use `encodeURIComponent` for encoding category names in URLs. This ensures special characters are properly handled when generating the link.

* `src/pages/archive/category/[category].astro`: 
  - Updated the `getStaticPaths` function to encode category names using `encodeURIComponent` when generating static paths.
  - Added `decodeURIComponent` to decode the category parameter from the URL for proper usage in the page. ([src/pages/archive/category/[category].astroL13-R19](diffhunk://#diff-114abcad97ac33210d98f53ee9ed9981f1dfb5079da767e0d848c3fbdb289ad7L13-R19))

* [`src/utils/url-utils.ts`](diffhunk://#diff-5d34aa8ca66f6e6adaf5b1a2550b242706a678e7a48666323d05deda3d8cdee6L22-R22): Modified the `getCategoryUrl` utility function to encode category names using `encodeURIComponent` when constructing category URLs. This ensures consistency across the application.