### PR TITLE
Fixed an issue where duplicate symbols would return a 404

### DIFF
--- a/src/components/widget/Tags.astro
+++ b/src/components/widget/Tags.astro
@@ -3,7 +3,8 @@
 import I18nKey from "../../i18n/i18nKey";
 import { i18n } from "../../i18n/translation";
 import { getTagList } from "../../utils/content-utils";
-import { getTagUrl } from "../../utils/url-utils";
+import { encodePathSegment } from "../../utils/encoding-utils";
+import { url as url_util } from "../../utils/url-utils";
 import ButtonTag from "../control/ButtonTag.astro";
 import WidgetLayout from "./WidgetLayout.astro";
 
@@ -22,10 +23,13 @@ const style = Astro.props.style;
 ---
 <WidgetLayout name={i18n(I18nKey.tags)} id="tags" isCollapsed={isCollapsed} collapsedHeight={COLLAPSED_HEIGHT} class={className} style={style}>
     <div class="flex gap-2 flex-wrap">
-        {tags.map(t => (
-            <ButtonTag href={getTagUrl(t.name.trim())} label={`View all posts with the ${t.name.trim()} tag`}>
-                {t.name.trim()}
-            </ButtonTag>
-        ))}
+        {tags.map(t => {
+            const encodedTag = encodePathSegment(t.name);
+            return (
+                <ButtonTag href={url_util(`/archive/tag/${encodedTag}/`)} label={`View all posts with the ${t.name} tag`}>
+                    {t.name}
+                </ButtonTag>
+            );
+        })}
     </div>
 </WidgetLayout>

--- a/src/content/posts/cjk-test.md
+++ b/src/content/posts/cjk-test.md
@@ -4,7 +4,7 @@ published: 2025-05-04
 updated: 2025-05-04
 description: 'CJK Test'
 image: ''
-tags: [C#, テスト, 技术, Fuwari]
+tags: [C#, テスト, 技术, Fuwari, C++]
 category: '技术'
 draft: true 
 ---

--- a/src/pages/archive/tag/[tag].astro
+++ b/src/pages/archive/tag/[tag].astro
@@ -10,47 +10,33 @@ export async function getStaticPaths() {
 	const posts = await getSortedPosts();
 
 	const allTags = posts.reduce<Set<string>>((acc, post) => {
-		if (Array.isArray(post.data.tags)) {
-			// biome-ignore lint/complexity/noForEach: <explanation>
-			post.data.tags.forEach((tag) => {
-				if (typeof tag === "string") {
-					acc.add(tag.trim());
-				} else {
-					acc.add(String(tag).trim());
-				}
-			});
-		} else if (post.data.tags && typeof post.data.tags === "string") {
-			// biome-ignore lint/complexity/noForEach: <explanation>
-			(post.data.tags as string)
-				.split(",")
-				.forEach((tag) => acc.add(tag.trim()));
+		for (const tag of post.data.tags) {
+			acc.add(tag);
 		}
 		return acc;
 	}, new Set());
 
 	const allTagsArray = Array.from(allTags);
 
-	// judge if the string is CJK
-	const isCJK = (str: string) =>
-		/[\u3000-\u9fff\uac00-\ud7af\u4e00-\u9faf]/.test(str);
-
 	const standardPaths = allTagsArray.map((tag) => ({
 		params: {
 			tag: encodePathSegment(tag),
 		},
 		props: {
-			decodedTag: tag,
+			decodedTag: tag.trim(),
 		},
 	}));
 
-	const nonEncodedCJKPaths = allTagsArray.filter(isCJK).map((tag) => ({
-		params: {
-			tag: tag, // keep CJK characters unencoded
-		},
-		props: {
-			decodedTag: tag,
-		},
-	}));
+	const nonEncodedCJKPaths = allTagsArray
+		.filter((tag) => /[\u3000-\u9fff\uac00-\ud7af\u4e00-\u9faf]/.test(tag))
+		.map((tag) => ({
+			params: {
+				tag: tag.trim(), // Do not encode CJK characters
+			},
+			props: {
+				decodedTag: tag.trim(),
+			},
+		}));
 
 	return [...standardPaths, ...nonEncodedCJKPaths];
 }

--- a/src/utils/encoding-utils.ts
+++ b/src/utils/encoding-utils.ts
@@ -9,8 +9,6 @@
  * @returns The encoded string
  */
 export function encodePathSegment(value: string): string {
-	if (!value) return "";
-
 	return encodeURIComponent(value.trim());
 }
 
@@ -21,12 +19,5 @@ export function encodePathSegment(value: string): string {
  * @returns Decoded string
  */
 export function decodePathSegment(value: string): string {
-	if (!value) return "";
-
-	try {
-		return decodeURIComponent(value);
-	} catch (e) {
-		console.error(`Failed to decode path segment: ${value}`, e);
-		return value;
-	}
+	return decodeURIComponent(value);
 }

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -23,12 +23,12 @@ export function getTagUrl(tag: string): string {
 	// use common encoding function
 	const encodedTag = encodePathSegment(tag);
 	const tagUrl = `/archive/tag/${encodedTag}/`;
-	console.log(`Generating URL for tag "${tag.trim()}" => "${tagUrl}"`);
+	// console.log(`Generating URL for tag "${tag.trim()}" => "${tagUrl}"`);
 	return url(tagUrl);
 }
 
 export function getCategoryUrl(category: string): string {
-	console.log(`category: ${category}`);
+	// console.log(`category: ${category}`);
 	if (!category) return url("/archive/category/");
 
 	const trimmedCategory = category.trim();


### PR DESCRIPTION
This pull request includes changes to improve tag encoding, simplify tag handling, and make minor content and logging updates. The most significant updates involve replacing custom URL encoding with a reusable utility function, streamlining tag processing, and cleaning up unnecessary code.

### Tag Encoding and URL Handling:
* Replaced `getTagUrl` with a combination of `encodePathSegment` and `url` utilities for tag URLs in `Tags.astro`. This ensures consistent encoding and URL generation. (`src/components/widget/Tags.astro`, [[1]](diffhunk://#diff-717ccf3787b3f8eb930b9b9598e58a96bdbb0b183d95c9eee0ef3d8550de3284L6-R7) [[2]](diffhunk://#diff-717ccf3787b3f8eb930b9b9598e58a96bdbb0b183d95c9eee0ef3d8550de3284L25-R33)
* Removed redundant checks and error handling from `encodePathSegment` and `decodePathSegment` for simplicity. (`src/utils/encoding-utils.ts`, [[1]](diffhunk://#diff-09a7694b01dcbd41c0f5d5de2abe15301f799e91e9d5c5e4e27d15969551ed1eL12-L13) [[2]](diffhunk://#diff-09a7694b01dcbd41c0f5d5de2abe15301f799e91e9d5c5e4e27d15969551ed1eL24-L31)

### Tag Processing Simplification:
* Simplified tag extraction logic in `getStaticPaths` by removing unnecessary type checks and trimming operations, and directly using the reusable encoding utility. (`src/pages/archive/tag/[tag].astro`, [src/pages/archive/tag/[tag].astroL13-R37](diffhunk://#diff-d7e2bb9688cf74b66a4bbe92a5590f7c7bb0e4b6b808c9d3e14bd6d6e3709573L13-R37))

### Minor Updates:
* Added a new tag (`C++`) to the metadata of `cjk-test.md`. (`src/content/posts/cjk-test.md`, [src/content/posts/cjk-test.mdL7-R7](diffhunk://#diff-c9c76c8ee7819bb2b9558d4b6992e7c906ee03f505561fceafba899ff04e77c9L7-R7))
* Commented out debug log statements in `getTagUrl` and `getCategoryUrl` to clean up console output. (`src/utils/url-utils.ts`, [src/utils/url-utils.tsL26-R31](diffhunk://#diff-5d34aa8ca66f6e6adaf5b1a2550b242706a678e7a48666323d05deda3d8cdee6L26-R31))