### PR TITLE
fix: improve category URL handling with additional checks

### DIFF
--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -1,3 +1,6 @@
+import I18nKey from "@i18n/i18nKey";
+import { i18n } from "@i18n/translation";
+
 export function pathsEqual(path1: string, path2: string) {
 	const normalizedPath1 = path1.replace(/^\/|\/$/g, "").toLowerCase();
 	const normalizedPath2 = path2.replace(/^\/|\/$/g, "").toLowerCase();
@@ -19,7 +22,12 @@ export function getTagUrl(tag: string): string {
 }
 
 export function getCategoryUrl(category: string): string {
-	if (!category) return url("/archive/");
+	if (
+		!category ||
+		category.trim() === "" ||
+		category.trim() === i18n(I18nKey.uncategorized)
+	)
+		return url("/archive/");
 	return url(`/archive/?category=${encodeURIComponent(category.trim())}`);
 }
 

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -25,7 +25,7 @@ export function getCategoryUrl(category: string): string {
 	if (
 		!category ||
 		category.trim() === "" ||
-		category.trim() === i18n(I18nKey.uncategorized)
+		category.trim().toLowerCase() === i18n(I18nKey.uncategorized).toLowerCase()
 	)
 		return url("/archive/");
 	return url(`/archive/?category=${encodeURIComponent(category.trim())}`);


### PR DESCRIPTION
This pull request improves URL handling in the `src/utils/url-utils.ts` file by introducing internationalization support and enhancing the logic for generating category URLs.

### Internationalization support:

* [`src/utils/url-utils.ts`](diffhunk://#diff-5d34aa8ca66f6e6adaf5b1a2550b242706a678e7a48666323d05deda3d8cdee6R1-R3): Added imports for `I18nKey` and `i18n` to enable internationalization functionality.

### Enhanced category URL generation:

* [`src/utils/url-utils.ts`](diffhunk://#diff-5d34aa8ca66f6e6adaf5b1a2550b242706a678e7a48666323d05deda3d8cdee6L22-R30): Updated the `getCategoryUrl` function to handle cases where the category is empty, consists only of whitespace, or matches the localized "uncategorized" string. These cases now return the archive URL (`"/archive/"`).