### PR TITLE
Improving contrast TOC light theme

### DIFF
--- a/src/styles/variables.styl
+++ b/src/styles/variables.styl
@@ -90,8 +90,8 @@ define({
   --admonitions-color-warning: oklch(0.7 0.14 60) oklch(0.75 0.14 60)
   --admonitions-color-caution: oklch(0.6 0.2 25) oklch(0.65 0.2 25)
 
-  --toc-badge-bg: oklch(0.9 0.045 var(--hue)) var(--btn-regular-bg)
-  --toc-btn-hover: oklch(0.92 0.015 var(--hue)) oklch(0.22 0.02 var(--hue))
+  --toc-badge-bg: oklch(0.89 0.050 var(--hue)) var(--btn-regular-bg)
+  --toc-btn-hover: oklch(0.926 0.015 var(--hue)) oklch(0.22 0.02 var(--hue))
   --toc-btn-active: oklch(0.90 0.015 var(--hue)) oklch(0.25 0.02 var(--hue))
   --toc-width: calc((100vw - var(--page-width)) / 2 - 1rem)
   --toc-item-active: oklch(0.70 0.13 var(--hue)) oklch(0.35 0.07 var(--hue))


### PR DESCRIPTION
I'm not a UI pro, nor do I currently have my main monitor available for proper display, but I'd say this improves the contrast and visibility of the TOC in the light theme, but try on your side and decide.