### PR TITLE
fix(content): handle blank frontmatter values from Obsidian

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -6,11 +6,31 @@ const postsCollection = defineCollection({
 		published: z.date(),
 		updated: z.date().optional(),
 		draft: z.boolean().optional().default(false),
-		description: z.string().nullable().transform(val => val ?? ""),
-		image: z.string().nullable().transform(val => val ?? ""),
-		tags: z.array(z.string()).nullable().transform(val => val ?? []),
-		category: z.string().nullable().transform(val => val ?? ""),
-		lang: z.string().nullable().transform(val => val ?? ""),
+		description: z
+			.string()
+			.optional()
+			.nullable()
+			.transform((val) => val ?? ""),
+		image: z
+			.string()
+			.optional()
+			.nullable()
+			.transform((val) => val ?? ""),
+		tags: z
+			.array(z.string())
+			.optional()
+			.nullable()
+			.transform((val) => val ?? []),
+		category: z
+			.string()
+			.optional()
+			.nullable()
+			.transform((val) => val ?? ""),
+		lang: z
+			.string()
+			.optional()
+			.nullable()
+			.transform((val) => val ?? ""),
 
 		/* For internal use */
 		prevTitle: z.string().default(""),

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -6,11 +6,11 @@ const postsCollection = defineCollection({
 		published: z.date(),
 		updated: z.date().optional(),
 		draft: z.boolean().optional().default(false),
-		description: z.string().optional().default(""),
-		image: z.string().optional().default(""),
-		tags: z.array(z.string()).optional().default([]),
-		category: z.string().optional().nullable().default(""),
-		lang: z.string().optional().default(""),
+		description: z.string().nullable().transform(val => val ?? ""),
+		image: z.string().nullable().transform(val => val ?? ""),
+		tags: z.array(z.string()).nullable().transform(val => val ?? []),
+		category: z.string().nullable().transform(val => val ?? ""),
+		lang: z.string().nullable().transform(val => val ?? ""),
 
 		/* For internal use */
 		prevTitle: z.string().default(""),


### PR DESCRIPTION
## Description
Obsidian and similar note-taking apps leave empty frontmatter fields blank (null) rather than using empty strings ("") or arrays ([]).
This caused schema validation errors in our content collections.
This PR adds proper handling for these cases by:
- Making most optional fields nullable
- Transforming null values to appropriate defaults:
  • null strings → ""
  • null arrays → []
  • missing booleans → false

![Example of blank frontmatter fields in Obsidian](https://github.com/user-attachments/assets/d8a7749f-8716-4010-8d96-9f2befc1857c)
*Obsidian's frontmatter: empty fields remain blank (null) rather than using empty strings or arrays*