### PR TITLE
Potentially fixing markdown link style

### DIFF
--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -28,8 +28,6 @@
         &:hover, &:active {
             @apply decoration-transparent;
             background: var(--btn-plain-bg-hover);
-            border-bottom: 1px dashed var(--link-hover);
-            text-decoration: none;
         }
     }
 


### PR DESCRIPTION
I observed a strange flashing of the underline when hovering out of a link in markdown.

I am not sure if this is intended or a mistake, so feel free to close this PR is this is indeed the intended behavior, cause I'm just not sure.

![image](https://github.com/user-attachments/assets/a3ae0637-9cf9-49f3-8140-5a244e24a69a)
