### PR TITLE
fix: remove non-existent 'link' class from Tailwind @apply directive

### DIFF
--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -20,7 +20,7 @@
     }
 
     a:not(.no-styling) {
-        @apply relative bg-none link font-medium text-[var(--primary)]
+        @apply relative bg-none font-medium text-[var(--primary)]
         underline decoration-[var(--link-underline)] decoration-1 decoration-dashed underline-offset-4;
         box-decoration-break: clone;
         -webkit-box-decoration-break: clone;


### PR DESCRIPTION
- Remove 'link' class from @apply directive in markdown.css line 23
- The 'link' class is not a valid Tailwind CSS utility class
- This fixes the build error: 'The link class does not exist'
- Build now completes successfully