### PR TITLE
Replacing hardcoded style for existing variable in Button Link

### DIFF
--- a/src/components/control/ButtonLink.astro
+++ b/src/components/control/ButtonLink.astro
@@ -33,7 +33,7 @@ const { badge, url, label } = Astro.props;
             { badge !== undefined && badge !== null && badge !== '' &&
                 <div class="transition px-2 h-7 ml-4 min-w-[2rem] rounded-lg text-sm font-bold
                     text-[var(--btn-content)] dark:text-[var(--deep-text)]
-                    bg-[oklch(0.95_0.025_var(--hue))] dark:bg-[var(--primary)]
+                    bg-[var(--btn-regular-bg)] dark:bg-[var(--primary)]
                     flex items-center justify-center">
                     { badge }
                 </div>


### PR DESCRIPTION
For some reason, there's a hardcoded style for the background when there's already a variable for these values being used in other places.