### PR TITLE
fix:  missing toc if base url is set

### DIFF
--- a/src/components/widget/TOC.astro
+++ b/src/components/widget/TOC.astro
@@ -1,7 +1,8 @@
 ---
 import type { MarkdownHeading } from "astro";
 import { siteConfig } from "../../config";
-import { url } from "../../utils/url-utils"
+import { url } from "../../utils/url-utils";
+
 interface Props {
 	class?: string;
 	headings: MarkdownHeading[];

--- a/src/components/widget/TOC.astro
+++ b/src/components/widget/TOC.astro
@@ -1,7 +1,7 @@
 ---
 import type { MarkdownHeading } from "astro";
 import { siteConfig } from "../../config";
-
+import { url } from "../../utils/url-utils"
 interface Props {
 	class?: string;
 	headings: MarkdownHeading[];
@@ -15,8 +15,7 @@ for (const heading of headings) {
 }
 
 const className = Astro.props.class;
-
-const isPostsRoute = Astro.url.pathname.startsWith("/posts/");
+const isPostsRoute = Astro.url.pathname.startsWith(url("/posts/"));
 
 const removeTailingHash = (text: string) => {
 	let lastIndexOfHash = text.lastIndexOf("#");


### PR DESCRIPTION
Fix missing table of content if base url is set, as we currently display it only if url starts with `/posts/` and thats not true in case of set base url, e.g. in gh pages deployment for repository.

Also, its real fix for https://github.com/saicaca/fuwari/issues/475