### PR TITLE
fix: explicitly define spec collection to remove auto-generation warning

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -19,6 +19,9 @@ const postsCollection = defineCollection({
 		nextSlug: z.string().default(""),
 	}),
 });
+
+const specCollection = defineCollection({});
 export const collections = {
 	posts: postsCollection,
+	spec: specCollection,
 };


### PR DESCRIPTION
Explicitly defined the spec collection in `config.ts` to replace the deprecated auto-generation behavior and eliminate the warning during build.

```bash
➜ fuwari fix-warning ✗ pnpm dev   

> fuwari@0.0.1 dev /home/cherry/fuwari
> astro dev

17:06:34 [types] Generated 0ms

Auto-generating collections for folders in "src/content/" that are not defined as collections.
This is deprecated, so you should define these collections yourself in "src/content.config.ts".
The following collections have been auto-generated: spec

17:06:34 [content] Syncing content
17:06:34 [content] Synced content
17:06:34 [vite] Forced re-optimization of dependencies
```