### PR TITLE
fix: Correct language setting reminder, zh-CN -> zh_CN

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ import { LinkPreset } from "./types/config";
 export const siteConfig: SiteConfig = {
 	title: "Fuwari",
 	subtitle: "Demo Site",
-	lang: "en", // Language code, e.g. 'en', 'zh-CN', 'ja', etc.
+	lang: "en", // Language code, e.g. 'en', 'zh_CN', 'ja', etc.
 	themeColor: {
 		hue: 250, // Default hue for the theme color, from 0 to 360. e.g. red: 0, teal: 200, cyan: 250, pink: 345
 		fixed: false, // Hide the theme color picker for visitors


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (fix an inconsistency in comments)

---

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

---

## Related Issue

---

## Changes

Correct language setting reminder, zh-CN -> zh_CN .

---

## How To Test

This change only involves a text comment and does not affect any functionality. No specific testing is required.

---

## Screenshots (if applicable)

---

## Additional Notes

Before this fix, if the user filled in 'zh-CN' in SiteConfig, the deployment result was 'en'.