### PR TITLE
fix(TOC): hide active overlay when no sections active

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ pnpm-debug.log*
 package-lock.json
 bun.lockb
 yarn.lock
+
+# ide
+.idea
+*.iml

--- a/src/components/widget/TOC.astro
+++ b/src/components/widget/TOC.astro
@@ -55,7 +55,7 @@ const maxLevel = siteConfig.toc.depth;
                 }]}>{removeTailingHash(heading.text)}</div>
             </a>
     )}
-    <div id="active-indicator" class:list={[{'hidden': headings.length == 0}, "-z-10 absolute bg-[var(--toc-btn-hover)] left-0 right-0 rounded-xl transition-all " +
+    <div id="active-indicator" style="opacity: 0" class:list={[{'hidden': headings.length == 0}, "-z-10 absolute bg-[var(--toc-btn-hover)] left-0 right-0 rounded-xl transition-all " +
         "group-hover:bg-transparent border-2 border-[var(--toc-btn-hover)] group-hover:border-[var(--toc-btn-active)] border-dashed"]}></div>
 </table-of-contents>}
 
@@ -97,7 +97,7 @@ class TableOfContents extends HTMLElement {
 
     toggleActiveHeading = () => {
         let i = this.active.length - 1;
-        let min = this.active.length - 1, max = 0;
+		let min = this.active.length - 1, max = -1;
         while (i >= 0 && !this.active[i]) {
             this.tocEntries[i].classList.remove(this.visibleClass);
             i--;
@@ -112,11 +112,15 @@ class TableOfContents extends HTMLElement {
             this.tocEntries[i].classList.remove(this.visibleClass);
             i--;
         }
-        let parentOffset = this.tocEl?.getBoundingClientRect().top || 0;
-        let scrollOffset = this.tocEl?.scrollTop || 0;
-        let top = this.tocEntries[min].getBoundingClientRect().top - parentOffset + scrollOffset;
-        let bottom = this.tocEntries[max].getBoundingClientRect().bottom - parentOffset + scrollOffset;
-        this.activeIndicator?.setAttribute("style", `top: ${top}px; height: ${bottom - top}px`);
+        if (min > max) {
+            this.activeIndicator?.setAttribute("style", `opacity: 0`);
+        } else {
+            let parentOffset = this.tocEl?.getBoundingClientRect().top || 0;
+            let scrollOffset = this.tocEl?.scrollTop || 0;
+            let top = this.tocEntries[min].getBoundingClientRect().top - parentOffset + scrollOffset;
+            let bottom = this.tocEntries[max].getBoundingClientRect().bottom - parentOffset + scrollOffset;
+            this.activeIndicator?.setAttribute("style", `top: ${top}px; height: ${bottom - top}px`);
+        }
     };
 
     scrollToActiveHeading = () => {

--- a/src/components/widget/TOC.astro
+++ b/src/components/widget/TOC.astro
@@ -97,7 +97,7 @@ class TableOfContents extends HTMLElement {
 
     toggleActiveHeading = () => {
         let i = this.active.length - 1;
-		let min = this.active.length - 1, max = -1;
+        let min = this.active.length - 1, max = -1;
         while (i >= 0 && !this.active[i]) {
             this.tocEntries[i].classList.remove(this.visibleClass);
             i--;


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
N/A

## Changes

<!-- Please describe the changes you made in this pull request. -->

Properly update the activate indicator when no sections are active


## How To Test

<!-- Please describe how you tested your changes. -->

Create a long document with no markdown headers towards the top. When the page is scrolled all the way to the top (and no headers are visible on the screen), the active sections overlay in the Table of Contents breaks, and displays as a single line at the very bottom of the ToC.

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->

Here's the broken line in the ToC:
<img width="1591" height="360" alt="image" src="https://github.com/user-attachments/assets/24496341-0a25-41ae-bce7-213fe55f4cdf" />



## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->

Here's a sample article that will trigger the bug:
```md
---
title: Test
published: 2025-08-07
tags: [Markdown, Blogging, Demo]
category: Examples
draft: true
---
f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

f

# This Article is a Draft

This article is currently in a draft state and is not published. Therefore, it will not be visible to the general audience. The content is still a work in progress and may require further editing and review.

When the article is ready for publication, you can update the "draft" field to "false" in the Frontmatter:


# This Article is a Draft
abc

## This Article is a Draft
abc

## This Article is a Draft
abc

## This Article is a Draft
abc

## This Article is a Draft
abc


# This Article is a Draft
abc
```