### PR TITLE
fix: define fonts for code block titles and language badges

### DIFF
--- a/src/plugins/expressive-code/language-badge.ts
+++ b/src/plugins/expressive-code/language-badge.ts
@@ -15,6 +15,7 @@ export function pluginLanguageBadge() {
         top: 0.5rem;
         padding: 0.1rem 0.5rem;
         content: attr(data-language);
+        font-family: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
         font-size: 0.75rem;
         font-weight: bold;
         text-transform: uppercase;

--- a/src/styles/expressive-code.css
+++ b/src/styles/expressive-code.css
@@ -1,3 +1,9 @@
-.expressive-code .frame {
-  @apply !shadow-none;
+.expressive-code {
+    .frame {
+        @apply !shadow-none;
+    }
+
+    .title {
+        font-family: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

Specify JetBrains Mono for code block titles and language badges to unify code block fonts.

## How To Test

Create sample content with one titled code block and one untitled code block.

## Screenshots (if applicable)

Before: 
<img width="1071" height="637" alt="图片" src="https://github.com/user-attachments/assets/8bd13594-c9bb-4903-87b2-7c7644f4544d" />

After:
<img width="1033" height="618" alt="图片" src="https://github.com/user-attachments/assets/b6dbc92d-2462-4990-9606-36b00b8b4e2e" />

## Additional Notes

Sometimes the compiled result breaks the code block styles, but I’m not sure what causes it. You can visit <https://xeonzilla.top/posts/twikoo-cloudflare_update/#%E6%9B%B4%E6%96%B0%E4%BE%9D%E8%B5%96> to see how the fonts look when applied.
