### PR TITLE
fix: add display inline-block to link styles in markdown.css

### DIFF
--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -24,6 +24,7 @@
         underline decoration-[var(--link-underline)] decoration-1 decoration-dashed underline-offset-4;
         box-decoration-break: clone;
         -webkit-box-decoration-break: clone;
+        display: inline-block;
     
         &:hover, &:active {
             @apply decoration-transparent;


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

无

## Changes

修复了在链接与文字位于同一行并被迫换行时，背景块显示被截断或不显示等跨行问题。  
现在背景能够完整覆盖文字与链接，即使发生换行也不会样式异常。

## How To Test

1. 在任意文章中添加一段文字与一定长度的链接，并放在同一行。  
2. 调整窗口宽度，触发链接换行。  
3. 观察背景块是否在换行处依然连续覆盖。

## Screenshots

_修复前：_  
<details>
<summary>点击展开查看详情</summary>

<img width="436" height="836" alt="屏幕截图 2025-08-12 171418" src="https://github.com/user-attachments/assets/2190fa62-dcc3-4857-ac7e-be800e9a6320" />

</details>

_修复后：_  
<details>
<summary>点击展开查看详情</summary>

<img width="436" height="836" alt="屏幕截图 2025-08-12 171718" src="https://github.com/user-attachments/assets/f17ae221-431c-4e08-81ae-e0b73d334dea" />

</details>

## Additional Notes

无
