### PR TITLE
Visual Improvement: Automatically Wrap Icons in Social Links List instead of Squeezing

### DIFF
--- a/src/components/widget/Profile.astro
+++ b/src/components/widget/Profile.astro
@@ -22,7 +22,7 @@ const config = profileConfig;
         <div class="font-bold text-xl text-center mb-1 dark:text-neutral-50 transition">{config.name}</div>
         <div class="h-1 w-5 bg-[var(--primary)] mx-auto rounded-full mb-2 transition"></div>
         <div class="text-center text-neutral-400 mb-2.5 transition">{config.bio}</div>
-        <div class="flex gap-2 justify-center mb-1">
+        <div class="flex flex-wrap gap-2 justify-center mb-1">
             {config.links.length > 1 && config.links.map(item =>
                     <a rel="me" aria-label={item.name} href={item.url} target="_blank" class="btn-regular rounded-lg h-10 w-10 active:scale-90">
                         <Icon name={item.icon} class="text-[1.5rem]"></Icon>


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
None


## Changes

<!-- Please describe the changes you made in this pull request. -->
Added `flex-wrap` to make icons automatically wrap.

## How To Test

<!-- Please describe how you tested your changes. -->
When there exists many social links in the profile, currently there is no wrapping and the icons squeeze together. This PR fixed the problem by automatically wrapping the icon list, keeping the original style.

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
Before:

<img width="366" height="571" alt="屏幕截图_20250821_174628" src="https://github.com/user-attachments/assets/7fe75632-78ca-471f-9552-87c67f294443" />

After:

<img width="373" height="627" alt="屏幕截图_20250821_174605" src="https://github.com/user-attachments/assets/6f19bf8c-6b03-4008-9871-3f5f67398d12" />


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
