### PR TITLE
Fix(ci)/Set version and add permissions for CI

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -9,12 +9,14 @@ on:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Biome
         uses: biomejs/setup-biome@f382a98e582959e6aaac8e5f8b17b31749018780 # v2.5.0
         with:
-          version: latest
+          version: 2.1.3
       - name: Run Biome
         run: biome ci ./src --reporter=github


### PR DESCRIPTION
Set specific version for Biome and add permissions.

## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please describe):

## Checklist

- [ ] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [ ] I have checked to ensure that this Pull Request is not for personal changes.
- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings.

## Related Issue

This pull request fully resolves the issues raised in PR #601 .

## Changes

This PR introduces two key improvements to our CI pipeline:

Pinned Biome Version: The Biome version used in the CI workflow is now explicitly set. This ensures that the CI environment uses the exact same version of Biome as our local development setups, guaranteeing consistent linting and formatting results and preventing discrepancies.

Added Workflow Permissions: Following the official template provided by Biome, a `permissions` block has been added to the GitHub Actions workflow. This addresses a security report from GitHub by explicitly defining read-only permissions for the job, adhering to the principle of least privilege.


## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
