### PR TITLE
fix: center postcard cover image

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -80,7 +80,7 @@ const { remarkPluginFrontmatter } = await entry.render();
     {hasCover && <a href={url} aria-label={title}
                     class:list={["group",
                         "max-h-[20vh] md:max-h-none mx-4 mt-4 -mb-2 md:mb-0 md:mx-0 md:mt-0",
-                        "md:w-[var(--coverWidth)] relative md:absolute md:top-3 md:bottom-3 md:right-3 rounded-xl overflow-hidden active:scale-95"
+                        "md:w-[var(--coverWidth)] relative md:absolute md:top-3 md:bottom-3 md:right-3 rounded-xl overflow-hidden active:scale-95 flex items-center"
                     ]} >
         <div class="absolute pointer-events-none z-10 w-full h-full group-hover:bg-black/30 group-active:bg-black/50 transition"></div>
         <div class="absolute pointer-events-none z-20 w-full h-full flex items-center justify-center ">


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
No

## Changes

<!-- Please describe the changes you made in this pull request. -->
Center postcard cover image.
Currently, the cover image is vertically centered on desktop (visually), but not on mobile.

## How To Test

<!-- Please describe how you tested your changes. -->
Create a post with a cover and use dev tools to simulate mobile.

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
Before:
<img width="540" height="319" alt="before" src="https://github.com/user-attachments/assets/869c67c5-7cf8-42ae-8087-43e1fc3efd96" />

After:
<img width="539" height="331" alt="after" src="https://github.com/user-attachments/assets/6700480b-42f3-46c7-b881-9789ef3bc4d5" />

## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
I'm not sure if this is really a bug, but this change aims to make the behavior consistent between desktop and mobile.
