### PR TITLE
Bug Fix: Correctly Support `> [!IMPORTANT]`s and `> [!CAUTION]`s in Admonitions

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -125,6 +125,11 @@ export default defineConfig({
 						important: (x, y) => AdmonitionComponent(x, y, "important"),
 						caution: (x, y) => AdmonitionComponent(x, y, "caution"),
 						warning: (x, y) => AdmonitionComponent(x, y, "warning"),
+						// the `remarkGithubAdmonitionsToDirectives` plugin generates
+						// `:::info` directives for `> [!IMPORTANT]` and `:::danger`s for `> [!CAUTION]`
+						// make it happy
+						info: (x, y) => AdmonitionComponent(x, y, 'important'),
+						danger: (x, y) => AdmonitionComponent(x, y, 'caution'),
 					},
 				},
 			],


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->

It is said that fuwari supports both markdown directives and the github syntax like `> [!IMPORTANT]` for admonition cards. However, for the github syntax, only `> [!NOTE]`, `> [!TIP]` and `> [!WARNING]` function correctly and `> [!IMPORTANT]` and `> [!CAUTION]` do not.

This is because the `remarkGithubAdmonitionsToDirectives` used to support the github syntax generates `:::info`s and `:::danger`s, while fuwari expect that to be `:::important`s and `:::caution`s to render the admonitions.


## Changes

<!-- Please describe the changes you made in this pull request. -->

Edit the config to adapt to the markdown directives generated by the `remarkGithubAdmonitionsToDirectives` .


## How To Test

<!-- Please describe how you tested your changes. -->

Write an `> [!IMPORTANT]` to any post.

For example, my post:

```markdown
> [!IMPORTANT]
> 本项目被迁移至 [Cloudflare](https://efzgkb-g12-math.pages.dev/) , 原有 [Github Pages](https://misaka10987.github.io/site-efzgkb-g12-math) 链接作废。
```

Before

<img width="561" height="71" alt="图片" src="https://github.com/user-attachments/assets/b6cdb746-e26e-4e0a-92db-aaebaff4a173" />

After

<img width="561" height="116" alt="图片" src="https://github.com/user-attachments/assets/d89c168d-447c-4401-8883-b92f6034e853" />


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
