### PR TITLE
fix(ui): reposition back-to-top button for correct visibility on desk…

### DIFF
--- a/src/components/control/BackToTop.astro
+++ b/src/components/control/BackToTop.astro
@@ -3,7 +3,7 @@ import { Icon } from "astro-icon/components";
 ---
 
 <!-- There can't be a filter on parent element, or it will break `fixed` -->
-<div class="back-to-top-wrapper hidden lg:block">
+<div class="back-to-top-wrapper block">
     <div id="back-to-top-btn" class="back-to-top-btn hide flex items-center rounded-2xl overflow-hidden transition" onclick="backToTop()">
         <button aria-label="Back to Top" class="btn-card h-[3.75rem] w-[3.75rem]">
             <Icon name="material-symbols:keyboard-arrow-up-rounded" class="mx-auto"></Icon>
@@ -16,8 +16,8 @@ import { Icon } from "astro-icon/components";
     width: 3.75rem
     height: 3.75rem
     position: absolute
-    right: 0
-    top: 0
+    right: 2rem
+    bottom: 10rem
     pointer-events: none
 
 .back-to-top-btn
@@ -25,20 +25,23 @@ import { Icon } from "astro-icon/components";
     font-size: 2.25rem
     font-weight: bold
     border: none
-    position: fixed
-    bottom: 10rem
+    position:absolute
+    bottom: 6rem
     opacity: 1
     cursor: pointer
-    transform: translateX(5rem)
+    transition: all 0.5s ease-in-out
+    transform: translateY(10rem)
     pointer-events: auto
     i
         font-size: 1.75rem
     &.hide
-        transform: translateX(5rem) scale(0.9)
+        transform: translateY(10rem) scale(0.9)
         opacity: 0
         pointer-events: none
     &:active
-      transform: translateX(5rem) scale(0.9)
+      transform: translateY(10rem) scale(0.9)
+
+
 
 </style>
 


### PR DESCRIPTION
## 📄 Description  
Repositioned the **Back to Top** button to ensure proper visibility and alignment on both desktop and mobile views.  
This update improves accessibility, spacing, and responsiveness across different screen sizes.  

---

## 📝 Change summary  
- Adjusted positioning of the **Back to Top** button  
- Ensured proper spacing and visibility on desktop and mobile  
- Improved responsive behavior and layout consistency  

---

## 📝 Types of changes  
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)  
- [ ] 🚨 Breaking change  
- [ ] ✨ New feature  
- [ ] ⏫ Version upgrade  
- [ ] 🧹 Refactor  
- [ ] 📝 Documentation  

---

## 🧪 How to test  
1. Open the application on both desktop and mobile viewports  
2. Scroll down the page to trigger the **Back to Top** button  
3. Verify that the button is correctly positioned and clearly visible on both views  

---

## 📸 Screenshots  

### 🖥️ Desktop  
#### Before  
<img width="1906" height="1083" alt="image" src="https://github.com/user-attachments/assets/14b1dd69-afc2-4f2e-857f-1244855948c5" />

#### After  
<img width="1913" height="1091" alt="image" src="https://github.com/user-attachments/assets/0300d215-14ae-459f-858d-d7f304957429" />

---

### 📱 Mobile  
#### Before  
<img width="371" height="676" alt="image" src="https://github.com/user-attachments/assets/5394f1f6-2d79-4508-aeb2-68d028240e77" />

#### After  
<img width="373" height="655" alt="image" src="https://github.com/user-attachments/assets/4ef58f8b-f1db-46b8-ba98-a3712dfe84c7" />
