### PR TITLE
feat: add OpenGraph image, tags, published/modified time, canonical URL support

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -31,7 +31,7 @@ interface Props {
 
 let { title, banner, description, lang, setOGTypeArticle } = Astro.props;
 
-let ogImage: string;
+let ogImage: string | undefined = undefined;
 
 if (banner && typeof banner === 'string' && banner.trim() !== '') {
   if (banner.startsWith('http://') || banner.startsWith('https://')) {
@@ -42,17 +42,24 @@ if (banner && typeof banner === 'string' && banner.trim() !== '') {
 }
 
 const slug = Astro.url.pathname.split('/').filter(Boolean).pop();
-let pageData = {};
+
+interface PageData {
+  published?: Date | string;
+  updated?: Date | string;
+  tags?: string[];
+}
+
+let pageData: PageData = {};
 
 try {
   const allEntries = await getCollection("posts");
   const entry = allEntries.find(e => e.slug === slug);
-  if (entry) pageData = entry.data;
+  if (entry) pageData = entry.data as PageData;
 } catch (e) {
-  // No data, slient fail
+  // No data, silent fail
 }
 
-const formatDate = (date) => {
+const formatDate = (date: Date | string | undefined): string | null => {
   if (!date) return null;
   if (date instanceof Date) {
     return date.toISOString().split('T')[0];
@@ -66,7 +73,7 @@ const formatDate = (date) => {
 const publishedDate = formatDate(pageData.published);
 const updatedDate = formatDate(pageData.updated);
 
-const tags = pageData.tags || [];
+const tags: string[] = pageData.tags || [];
 
 // apply a class to the body element to decide the height of the banner, only used for initial page load
 // Swup can update the body for each page visit, but it's after the page transition, causing a delay for banner height change
@@ -131,7 +138,7 @@ const bannerOffset =
 		{setOGTypeArticle ? (
 		<>
 			<meta property="og:type" content="article" />
-			{tags.map((tag) => (
+			{tags.map((tag: string) => (
 			<meta property="article:tag" content={tag} />
 			))}
 			{publishedDate && <meta property="article:published_time" content={publishedDate} />}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -30,6 +30,18 @@ interface Props {
 
 let { title, banner, description, lang, setOGTypeArticle } = Astro.props;
 
+const currentPath = Astro.url.pathname;
+
+let ogImage: string | undefined = undefined;
+
+if (banner && typeof banner === 'string' && banner.trim() !== '') {
+  if (banner.startsWith('http://') || banner.startsWith('https://')) {
+    ogImage = banner;
+  } else {
+    ogImage = new URL(banner, Astro.site || Astro.url.origin).href;
+  }
+}
+
 // apply a class to the body element to decide the height of the banner, only used for initial page load
 // Swup can update the body for each page visit, but it's after the page transition, causing a delay for banner height change
 // so use Swup hooks instead to change the height immediately when a link is clicked
@@ -93,11 +105,13 @@ const bannerOffset =
         ) : (
         <meta property="og:type" content="website" />
         )}
+		{ogImage && <meta property="og:image" content={ogImage} />}
 
 		<meta name="twitter:card" content="summary_large_image">
 		<meta property="twitter:url" content={Astro.url}>
 		<meta name="twitter:title" content={pageTitle}>
 		<meta name="twitter:description" content={description || pageTitle}>
+		{ogImage && <meta property="twitter:image" content={ogImage} />}
 
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,6 +19,7 @@ import { defaultFavicons } from "../constants/icon";
 import type { Favicon } from "../types/config";
 import { pathsEqual, url } from "../utils/url-utils";
 import "katex/dist/katex.css";
+import { getCollection } from "astro:content";
 
 interface Props {
 	title?: string;
@@ -39,6 +40,33 @@ if (banner && typeof banner === 'string' && banner.trim() !== '') {
     ogImage = new URL(banner, Astro.site || Astro.url.origin).href;
   }
 }
+
+const slug = Astro.url.pathname.split('/').filter(Boolean).pop();
+let pageData = {};
+
+try {
+  const allEntries = await getCollection("posts");
+  const entry = allEntries.find(e => e.slug === slug);
+  if (entry) pageData = entry.data;
+} catch (e) {
+  // No data, slient fail
+}
+
+const formatDate = (date) => {
+  if (!date) return null;
+  if (date instanceof Date) {
+    return date.toISOString().split('T')[0];
+  }
+  if (typeof date === 'string') {
+    return date.split('T')[0];
+  }
+  return null;
+};
+
+const publishedDate = formatDate(pageData.published);
+const updatedDate = formatDate(pageData.updated);
+
+const tags = pageData.tags || [];
 
 // apply a class to the body element to decide the height of the banner, only used for initial page load
 // Swup can update the body for each page visit, but it's after the page transition, causing a delay for banner height change
@@ -91,18 +119,27 @@ const bannerOffset =
 		<title>{pageTitle}</title>
 
 		<meta charset="UTF-8" />
+		<meta name="title" content={pageTitle} />
 		<meta name="description" content={description || pageTitle}>
 		<meta name="author" content={profileConfig.name}>
+		<link rel="canonical" href={Astro.url} />
 
 		<meta property="og:site_name" content={siteConfig.title}>
 		<meta property="og:url" content={Astro.url}>
 		<meta property="og:title" content={pageTitle}>
 		<meta property="og:description" content={description || pageTitle}>
 		{setOGTypeArticle ? (
-        <meta property="og:type" content="article" />
-        ) : (
-        <meta property="og:type" content="website" />
-        )}
+		<>
+			<meta property="og:type" content="article" />
+			{tags.map((tag) => (
+			<meta property="article:tag" content={tag} />
+			))}
+			{publishedDate && <meta property="article:published_time" content={publishedDate} />}
+			{updatedDate && <meta property="article:modified_time" content={updatedDate} />}
+		</>
+		) : (
+		<meta property="og:type" content="website" />
+		)}
 		{ogImage && <meta property="og:image" content={ogImage} />}
 
 		<meta name="twitter:card" content="summary_large_image">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -30,9 +30,7 @@ interface Props {
 
 let { title, banner, description, lang, setOGTypeArticle } = Astro.props;
 
-const currentPath = Astro.url.pathname;
-
-let ogImage: string | undefined = undefined;
+let ogImage: string;
 
 if (banner && typeof banner === 'string' && banner.trim() !== '') {
   if (banner.startsWith('http://') || banner.startsWith('https://')) {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
Resolves: https://github.com/saicaca/fuwari/issues/323
Resolves: https://github.com/saicaca/fuwari/issues/114

## Changes

<!-- Please describe the changes you made in this pull request. -->
- Add OG image, tags, published/modified time support (search engine will be able to know when you change the content)
- Add canonical URL support (avoid the past indexing issue with '/post/slug' or '/post/slug/', even though the issue was being addressed in another way)

## How To Test

<!-- Please describe how you tested your changes. -->
- Add a cover to the article and check if `og:image` and `twitter:image` are included.
- Check if `article:published_time`, `article:modified_time` (optional), `article:tag` is in the header. 
- Check if `rel="canonical"` is in the header.

## Screenshots (if applicable)
Tested here: https://www.opengraph.xyz
<img width="1704" height="819" alt="image" src="https://github.com/user-attachments/assets/df9a98d7-f907-48af-958b-abd9e7f5b3fd" />

Results from Bing:
<img width="894" height="581" alt="image" src="https://github.com/user-attachments/assets/c13a8eb2-4b53-4ae5-b8c4-4070cbfbd6f1" />
You can tell that newly indexed pages (result 2 & 3) now have their formatted date read from the Open Graph properties.

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes
This is the follow-up PR to: https://github.com/saicaca/fuwari/pull/66

I see two previous PRs for OG image generators, but before considering the generator, a simple basic implementation is okay for use, **_honestly_**.

Update: I changed my mind. I want to complete what I haven't finished in #66 once and for all, so I made new commits.
<!-- Any additional information that you want to share with the reviewer. -->
