### PR TITLE
fix: missing `/pagefind/pagefind.js` in generated pages from GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,4 +64,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Astro Build
-        run: pnpm astro build
+        run: pnpm run build


### PR DESCRIPTION
Fix `/pagefind/pagefind.js` 404 issue

## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
Fix: https://github.com/saicaca/fuwari/issues/705
Fix: https://github.com/saicaca/fuwari/issues/529

## Changes

<!-- Please describe the changes you made in this pull request. -->
Use `pnpm run build` instead of `pnpm astro build`

## How To Test

<!-- Please describe how you tested your changes. -->
I have identified that this command is causing the issue. 
To verify, please add an action to upload the `dist` directory.

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
Before:
<img width="810" height="471" alt="Image" src="https://github.com/user-attachments/assets/3a5bedac-8f7d-4cf4-8d1a-824c0e74ce3c" />

After:
<img width="960" height="606" alt="image" src="https://github.com/user-attachments/assets/def03e14-5fa8-4f03-a3db-073378745664" />

## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
I am not sure how repo maintainers able to make it work in Vercel, but the file is not there when I tried this.

I am sure I have executed `pnpm install --frozen-lockfile`, `pnpm astro check` before `pnpm astro build`.