### PR TITLE
Feature/unlisted

### DIFF
--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -67,6 +67,7 @@ image: /images/cover.jpg
 tags: [Foo, Bar]
 category: Front-end
 draft: false
+unlisted: false #Si es true, se oculta de la lista. Acceso solo vía enlace directo (URL). (Ver Unlisted-Posts_Feature.md para más info)
 ---
 ```
 

--- a/docs/README.id.md
+++ b/docs/README.id.md
@@ -66,6 +66,7 @@ tags: [Foo, Bar]
 category: Front-end
 draft: false
 lang: id   # Isi hanya jika bahasa postingan berbeda dari bahasa default di `config.ts`
+unlisted: false # Jika disetel ke true, sembunyikan dari daftar dan hanya dapat diakses melalui tautan langsung (URL). (Detail: lihat Unlisted-Posts_Feature.md)
 ---
 ```
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -67,6 +67,7 @@ image: /images/cover.jpg
 tags: [Foo, Bar]
 category: Front-end
 draft: false
+unlisted: false # trueの場合、一覧には表示されず直リンク(URL)でのみ閲覧 가능(アクセス可能)となります。(詳細は Unlisted-Posts_Feature.md を参照)
 ---
 ```
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -47,6 +47,8 @@ tags: [Foo, Bar]
 category: Front-end
 draft: false
 lang: jp      # 게시물의 언어가 `config.ts`의 사이트 언어와 다른 경우에만 설정합니다.
+unlisted: false # true 설정 시 목록에서 숨기고 직접 링크(URL)로만 접근 가능 (상세 정보: Unlisted-Posts_Feature.md 참고)
+
 ---
 ```
 ## 🧩 마크다운 확장 구문

--- a/docs/README.th.md
+++ b/docs/README.th.md
@@ -48,6 +48,7 @@ tags: [Foo, Bar]
 category: Front-end
 draft: false
 lang: jp      # เขียนค่านี้เมื่อภาษาของโพสต์นั้น ๆ แตกต่างจากภาษาของเว็บไซต์ที่ตั้งค่าไว้ใน `config.ts` เท่านั้น
+unlisted: false # หากตั้งค่าเป็น true จะถูกซ่อนจากรายการและเข้าถึงได้ผ่านลิงก์โดยตรง (URL) เท่านั้น (ดูรายละเอียดที่ Unlisted-Posts_Feature.md)
 ---
 ```
 

--- a/docs/README.vi.md
+++ b/docs/README.vi.md
@@ -48,6 +48,7 @@ tags: [Foo, Bar]
 category: Front-end
 draft: false
 lang: jp      # Chỉ đặt nếu ngôn ngữ của bài viết khác với ngôn ngữ của trang web trong `config.ts`
+unlisted: false # Nếu đặt là true, mục này sẽ bị ẩn khỏi danh sách và chỉ có thể truy cập qua liên kết trực tiếp (URL). (Chi tiết: xem Unlisted-Posts_Feature.md)
 ---
 ```
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -68,6 +68,7 @@ tags: [Foo, Bar]
 category: Front-end
 draft: false
 lang: jp      # 仅当文章语言与 `config.ts` 中的网站语言不同时需要设置
+unlisted: false # 如果设置为 true，将从列表中隐藏，只能通过直接链接 (URL) 访问。（详情请参阅: Unlisted-Posts_Feature.md）
 ---
 ```
 

--- a/pagefind.yml
+++ b/pagefind.yml
@@ -1,6 +1,5 @@
 exclude_selectors:
   - "span.katex"
   - "span.katex-display"
-  - "[data-pagefind-ignore]"
   - ".search-panel"
   - "#search-panel"

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,30 +1,30 @@
 import { defineCollection, z } from "astro:content";
 
 const postsCollection = defineCollection({
-    schema: z.object({
-        title: z.string(),
-        published: z.date(),
-        updated: z.date().optional(),
-        draft: z.boolean().optional().default(false),
-        description: z.string().optional().default(""),
-        image: z.string().optional().default(""),
-        tags: z.array(z.string()).optional().default([]),
-        category: z.string().optional().nullable().default(""),
-        lang: z.string().optional().default(""),
+	schema: z.object({
+		title: z.string(),
+		published: z.date(),
+		updated: z.date().optional(),
+		draft: z.boolean().optional().default(false),
+		description: z.string().optional().default(""),
+		image: z.string().optional().default(""),
+		tags: z.array(z.string()).optional().default([]),
+		category: z.string().optional().nullable().default(""),
+		lang: z.string().optional().default(""),
 		// Hide from lists/search, still accessible by direct URL
-        unlisted: z.boolean().optional().default(false), 
+		unlisted: z.boolean().optional().default(false),
 
-        /* For internal use */
-        prevTitle: z.string().default(""),
-        prevSlug: z.string().default(""),
-        nextTitle: z.string().default(""),
-        nextSlug: z.string().default(""),
-    }),
+		/* For internal use */
+		prevTitle: z.string().default(""),
+		prevSlug: z.string().default(""),
+		nextTitle: z.string().default(""),
+		nextSlug: z.string().default(""),
+	}),
 });
 const specCollection = defineCollection({
-    schema: z.object({}),
+	schema: z.object({}),
 });
 export const collections = {
-    posts: postsCollection,
-    spec: specCollection,
+	posts: postsCollection,
+	spec: specCollection,
 };

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,28 +1,30 @@
 import { defineCollection, z } from "astro:content";
 
 const postsCollection = defineCollection({
-	schema: z.object({
-		title: z.string(),
-		published: z.date(),
-		updated: z.date().optional(),
-		draft: z.boolean().optional().default(false),
-		description: z.string().optional().default(""),
-		image: z.string().optional().default(""),
-		tags: z.array(z.string()).optional().default([]),
-		category: z.string().optional().nullable().default(""),
-		lang: z.string().optional().default(""),
+    schema: z.object({
+        title: z.string(),
+        published: z.date(),
+        updated: z.date().optional(),
+        draft: z.boolean().optional().default(false),
+        description: z.string().optional().default(""),
+        image: z.string().optional().default(""),
+        tags: z.array(z.string()).optional().default([]),
+        category: z.string().optional().nullable().default(""),
+        lang: z.string().optional().default(""),
+		// Hide from lists/search, still accessible by direct URL
+        unlisted: z.boolean().optional().default(false), 
 
-		/* For internal use */
-		prevTitle: z.string().default(""),
-		prevSlug: z.string().default(""),
-		nextTitle: z.string().default(""),
-		nextSlug: z.string().default(""),
-	}),
+        /* For internal use */
+        prevTitle: z.string().default(""),
+        prevSlug: z.string().default(""),
+        nextTitle: z.string().default(""),
+        nextSlug: z.string().default(""),
+    }),
 });
 const specCollection = defineCollection({
-	schema: z.object({}),
+    schema: z.object({}),
 });
 export const collections = {
-	posts: postsCollection,
-	spec: specCollection,
+    posts: postsCollection,
+    spec: specCollection,
 };

--- a/src/content/posts/Unlisted-Posts-Feature.md
+++ b/src/content/posts/Unlisted-Posts-Feature.md
@@ -1,0 +1,64 @@
+---
+title: Unlisted Posts Feature
+published: 2026-01-19
+description: How to hide posts from lists while keeping them accessible via direct links.
+tags: [Example, Feature]
+category: Examples
+draft: false
+unlisted: false
+---
+
+##  🔍What is the "Unlisted" Feature?
+
+The `unlisted` feature allows you to hide specific posts from public listings while keeping them accessible via a direct URL. This is perfect for sharing content with a limited audience without cluttering your blog's main feed.
+
+## 🛠️ How to Use It
+
+Simply add `unlisted: true` to your post's frontmatter:
+
+```markdown
+---
+title: "My Secret Post"
+published: 2026-01-18
+unlisted: true
+---
+```
+
+### Where are Unlisted Posts Hidden?
+When a post is set to `unlisted: true`, it will **not** appear in:
+
+*    🏠**Home page** post list
+*    📂**Archive page**
+*    🏷️**Tag & Category** listings
+*    🔍**Search results** (Pagefind)
+*    📡**RSS feed**
+
+---
+
+##  How to Access Unlisted Posts
+
+Unlisted posts remain accessible **only via their direct URL**. The URL follows the standard pattern:
+
+`https://your-site.com/posts/[your-post-slug]/`
+
+> **Example:**
+> If your file is `unlisted-sample.md` and your site is `https://fuwari.vercel.app`, the URL will be:
+> [https://fuwari.vercel.app/posts/unlisted-sample/](https://fuwari.vercel.app/posts/unlisted-sample/)
+
+---
+
+## ⚠️ Security Note: Unlisted ≠ Private
+
+**This feature provides obscurity, not absolute privacy.**
+Anyone with the direct link can still view the content. If you need to restrict access to sensitive information, please use server-level authentication (e.g., Basic Auth or middleware).
+
+---
+
+## 💡 Use Cases
+
+*   **Draft Reviews:** Share a nearly-finished post with friends or colleagues for feedback.
+*   **Targeted Content:** Create guides or write-ups intended only for a specific group.
+*   **Clean Feed:** Prevent short notes or experimental posts from cluttering your main archive.
+
+
+

--- a/src/content/posts/guide/index.md
+++ b/src/content/posts/guide/index.md
@@ -35,7 +35,7 @@ draft: false
 | `tags`        | The tags of the post.                                                                                                                                                                                       |
 | `category`    | The category of the post.                                                                                                                                                                                   |
 | `draft`        | If this post is still a draft, which won't be displayed.                                                                                                                                                    |
-
+| `unlisted`   | **Hide post from lists.** Access is only possible via a direct URL. (See `Unlisted-Posts_Feature`)
 ## Where to Place the Post Files
 
 

--- a/src/content/posts/unlisted-sample.md
+++ b/src/content/posts/unlisted-sample.md
@@ -1,0 +1,12 @@
+---
+title: Unlisted Posts Feature
+published: 2026-01-19
+description: HI!!
+tags: [Example, Feature]
+category: Examples
+draft: false
+unlisted: true
+---
+HELLOOOOOOOOO
+This is unlisted posts......
+This post is unlisted and accessible only via URL.!!!!

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,9 +26,11 @@ interface Props {
 	description?: string;
 	lang?: string;
 	setOGTypeArticle?: boolean;
+	pagefindIgnoreAll?: boolean;
 }
 
-let { title, banner, description, lang, setOGTypeArticle } = Astro.props;
+let { title, banner, description, lang, setOGTypeArticle, pagefindIgnoreAll } =
+	Astro.props;
 
 // apply a class to the body element to decide the height of the banner, only used for initial page load
 // Swup can update the body for each page visit, but it's after the page transition, causing a delay for banner height change
@@ -75,6 +77,7 @@ const bannerOffset =
 <!DOCTYPE html>
 <html lang={siteLang} class="bg-[var(--page-bg)] transition text-[14px] md:text-[16px]"
 	  data-overlayscrollbars-initialize
+	  data-pagefind-ignore={pagefindIgnoreAll ? "all" : undefined}
 >
 	<head>
 

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -21,6 +21,7 @@ interface Props {
 	description?: string;
 	lang?: string;
 	setOGTypeArticle?: boolean;
+	pagefindIgnoreAll?: boolean;
 	headings?: MarkdownHeading[];
 }
 
@@ -30,6 +31,7 @@ const {
 	description,
 	lang,
 	setOGTypeArticle,
+	pagefindIgnoreAll,
 	headings = [],
 } = Astro.props;
 const hasBannerCredit =
@@ -41,7 +43,7 @@ const mainPanelTop = siteConfig.banner.enable
 	: "5.5rem";
 ---
 
-<Layout title={title} banner={banner} description={description} lang={lang} setOGTypeArticle={setOGTypeArticle}>
+<Layout title={title} banner={banner} description={description} lang={lang} setOGTypeArticle={setOGTypeArticle} pagefindIgnoreAll={pagefindIgnoreAll}>
 
 <!-- Navbar -->
 <slot slot="head" name="head"></slot>

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -15,7 +15,7 @@ import { profileConfig, siteConfig } from "../../config";
 import { formatDateToYYYYMMDD } from "../../utils/date-utils";
 
 export async function getStaticPaths() {
-    const blogEntries = await getSortedPosts({ includeUnlisted: true });
+	const blogEntries = await getSortedPosts({ includeUnlisted: true });
 	return blogEntries.map((entry) => ({
 		params: { slug: entry.slug },
 		props: { entry },

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -46,7 +46,7 @@ const jsonLd = {
 	// TODO include cover image here
 };
 ---
-<MainGridLayout banner={entry.data.image} title={entry.data.title} description={entry.data.description} lang={entry.data.lang} setOGTypeArticle={true} headings={headings}>
+<MainGridLayout banner={entry.data.image} title={entry.data.title} description={entry.data.description} lang={entry.data.lang} setOGTypeArticle={true} headings={headings} pagefindIgnoreAll={isUnlisted}>
     <script is:inline slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
     <div class="flex w-full rounded-[var(--radius-large)] overflow-hidden relative mb-4">
         <div

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -15,7 +15,7 @@ import { profileConfig, siteConfig } from "../../config";
 import { formatDateToYYYYMMDD } from "../../utils/date-utils";
 
 export async function getStaticPaths() {
-	const blogEntries = await getSortedPosts();
+    const blogEntries = await getSortedPosts({ includeUnlisted: true });
 	return blogEntries.map((entry) => ({
 		params: { slug: entry.slug },
 		props: { entry },
@@ -23,6 +23,7 @@ export async function getStaticPaths() {
 }
 
 const { entry } = Astro.props;
+const isUnlisted = entry.data.unlisted === true;
 const { Content, headings } = await entry.render();
 
 const { remarkPluginFrontmatter } = await entry.render();
@@ -48,9 +49,13 @@ const jsonLd = {
 <MainGridLayout banner={entry.data.image} title={entry.data.title} description={entry.data.description} lang={entry.data.lang} setOGTypeArticle={true} headings={headings}>
     <script is:inline slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
     <div class="flex w-full rounded-[var(--radius-large)] overflow-hidden relative mb-4">
-        <div id="post-container" class:list={["card-base z-10 px-6 md:px-9 pt-6 pb-4 relative w-full ",
-            {}
-        ]}>
+        <div
+            id="post-container"
+            class:list={[["card-base z-10 px-6 md:px-9 pt-6 pb-4 relative w-full ",
+                {}
+            ]]}
+            data-pagefind-ignore={isUnlisted ? "all" : undefined}
+        >
             <!-- word count and reading time -->
             <div class="flex flex-row text-black/30 dark:text-white/30 gap-5 mb-3 transition onload-animation">
                 <div class="flex flex-row items-center">

--- a/src/utils/content-utils.ts
+++ b/src/utils/content-utils.ts
@@ -3,13 +3,23 @@ import I18nKey from "@i18n/i18nKey";
 import { i18n } from "@i18n/translation";
 import { getCategoryUrl } from "@utils/url-utils.ts";
 
+type PostEntry = CollectionEntry<"posts">;
+
+// Unlisted posts are hidden from lists/search, but can be accessed by direct URL
+function isListedPost(post: PostEntry) {
+	return post.data.unlisted !== true;
+}
+
 // // Retrieve posts and sort them by publication date
-async function getRawSortedPosts() {
+async function getRawSortedPosts(options: { includeUnlisted?: boolean } = {}) {
 	const allBlogPosts = await getCollection("posts", ({ data }) => {
 		return import.meta.env.PROD ? data.draft !== true : true;
 	});
-
-	const sorted = allBlogPosts.sort((a, b) => {
+	// Default: exclude unlisted from lists. Use includeUnlisted for direct post pages.
+	const filteredPosts = options.includeUnlisted
+		? allBlogPosts
+		: allBlogPosts.filter((post) => isListedPost(post));
+	const sorted = filteredPosts.sort((a, b) => {
 		const dateA = new Date(a.data.published);
 		const dateB = new Date(b.data.published);
 		return dateA > dateB ? -1 : 1;
@@ -17,16 +27,19 @@ async function getRawSortedPosts() {
 	return sorted;
 }
 
-export async function getSortedPosts() {
-	const sorted = await getRawSortedPosts();
+export async function getSortedPosts(options: { includeUnlisted?: boolean } = {}) {
+	const sorted = await getRawSortedPosts(options);
+	const navPosts = options.includeUnlisted
+		? sorted.filter((post) => isListedPost(post))
+		: sorted;
 
-	for (let i = 1; i < sorted.length; i++) {
-		sorted[i].data.nextSlug = sorted[i - 1].slug;
-		sorted[i].data.nextTitle = sorted[i - 1].data.title;
+	for (let i = 1; i < navPosts.length; i++) {
+		navPosts[i].data.nextSlug = navPosts[i - 1].slug;
+		navPosts[i].data.nextTitle = navPosts[i - 1].data.title;
 	}
-	for (let i = 0; i < sorted.length - 1; i++) {
-		sorted[i].data.prevSlug = sorted[i + 1].slug;
-		sorted[i].data.prevTitle = sorted[i + 1].data.title;
+	for (let i = 0; i < navPosts.length - 1; i++) {
+		navPosts[i].data.prevSlug = navPosts[i + 1].slug;
+		navPosts[i].data.prevTitle = navPosts[i + 1].data.title;
 	}
 
 	return sorted;
@@ -56,8 +69,10 @@ export async function getTagList(): Promise<Tag[]> {
 		return import.meta.env.PROD ? data.draft !== true : true;
 	});
 
+	const listedPosts = allBlogPosts.filter((post) => isListedPost(post));
+
 	const countMap: { [key: string]: number } = {};
-	allBlogPosts.forEach((post: { data: { tags: string[] } }) => {
+	listedPosts.forEach((post: { data: { tags: string[] } }) => {
 		post.data.tags.forEach((tag: string) => {
 			if (!countMap[tag]) countMap[tag] = 0;
 			countMap[tag]++;
@@ -82,8 +97,9 @@ export async function getCategoryList(): Promise<Category[]> {
 	const allBlogPosts = await getCollection<"posts">("posts", ({ data }) => {
 		return import.meta.env.PROD ? data.draft !== true : true;
 	});
+	const listedPosts = allBlogPosts.filter((post) => isListedPost(post));
 	const count: { [key: string]: number } = {};
-	allBlogPosts.forEach((post: { data: { category: string | null } }) => {
+	listedPosts.forEach((post: { data: { category: string | null } }) => {
 		if (!post.data.category) {
 			const ucKey = i18n(I18nKey.uncategorized);
 			count[ucKey] = count[ucKey] ? count[ucKey] + 1 : 1;
@@ -112,3 +128,5 @@ export async function getCategoryList(): Promise<Category[]> {
 	}
 	return ret;
 }
+
+

--- a/src/utils/content-utils.ts
+++ b/src/utils/content-utils.ts
@@ -27,7 +27,9 @@ async function getRawSortedPosts(options: { includeUnlisted?: boolean } = {}) {
 	return sorted;
 }
 
-export async function getSortedPosts(options: { includeUnlisted?: boolean } = {}) {
+export async function getSortedPosts(
+	options: { includeUnlisted?: boolean } = {},
+) {
 	const sorted = await getRawSortedPosts(options);
 	const navPosts = options.includeUnlisted
 		? sorted.filter((post) => isListedPost(post))
@@ -128,5 +130,3 @@ export async function getCategoryList(): Promise<Category[]> {
 	}
 	return ret;
 }
-
-


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings. (Please see 'Additional Notes' for existing type errors)

## Related Issue

N/A

## Changes

I have added an **'Unlisted'** post feature. Posts marked as `unlisted: true` are hidden from public listings but remain accessible via a direct URL.

**Key exclusions:**
* 🏠 **Home page** list, 📂 **Archive page**, 🏷️ **Tag & Category** listings, 📡 **RSS feed**
* 🔍 **Search results** (Handled via `data-pagefind-ignore` in `[...slug].astro`)

**Documentation:**
* Updated READMEs in 7 languages (KO, EN, JA, ES, ID, TH, VI, ZH-CN).
* Added `Unlisted-Posts-Feature.md` for detailed guidance.

## How To Test

1. Create a new post with `unlisted: true` in its frontmatter.
2. Run the site and verify it does not appear on the Home, Archive, or Tag pages.
3. Access the post directly via its URL to ensure it renders correctly.
4. Use the search bar to confirm the unlisted post is not indexed by Pagefind.
5. (Optional) Check the `unlisted-sample.md` included in this PR.

## Screenshots (if applicable)

*(If you have a screenshot of a post being hidden or the Pagefind ignore attribute in devtools, please drag and drop it here)*

## Additional Notes

* **pnpm check & format**: Both commands were executed. 
* **Note on existing errors**: There are 2 pre-existing type errors in `Navbar.astro` and `archive.astro`. These are unrelated to my changes and were present in the base repository. My added logic functions as intended.
* **Translations**: Multilingual README updates were refined using AI for more natural phrasing.