### PR TITLE
feat: add table row colours and horizontal scroll bar

### DIFF
--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -117,5 +117,29 @@
         overflow-x: auto;
         margin: 1em 0;
     }
+
+    table {
+        @apply w-full border-collapse my-4;
+        overflow-x: auto;
+        display: block;
+        white-space: nowrap;
+    }
+
+    th, td {
+        @apply border border-[var(--line-color)] px-3 py-2 text-left;
+        min-width: 120px;
+    }
+
+    th {
+        @apply bg-[var(--btn-regular-bg)] font-semibold text-[var(--btn-content)];
+    }
+
+    td {
+        @apply bg-[var(--card-bg)];
+    }
+
+    tr:nth-child(even) td {
+        @apply bg-[var(--btn-plain-bg-hover)];
+    }
     
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
Resolve: https://github.com/saicaca/fuwari/issues/710

## Changes

<!-- Please describe the changes you made in this pull request. -->
1. Add horizontal scroll bar for tables
2. Add table row colours

## How To Test

<!-- Please describe how you tested your changes. -->
Insert a table like below:


| **Product Name**       | **Description**                          | **Features**                                   | **Price (USD)** | **Warranty Period** | **Available Colors**                    |
|------------------------|------------------------------------------|------------------------------------------------|------------------|---------------------|-----------------------------------------|
| UltraSmart TV 55"     | 4K Ultra HD Smart TV with voice control | 4K Resolution, HDR, Smart TV capabilities, Dolby Vision | $799.99          | 2 Years             | Black, Silver, Rose Gold                |
| PowerMax Blender       | High-performance kitchen blender          | 1200 Watts, 6-Speed Settings, Pulse Function   | $129.99          | 1 Year              | Red, Black, White                        |
| Quantum Laptop         | Lightweight and powerful laptop         | Intel i7, 16GB RAM, 512GB SSD, 15.6" Display  | $1,299.99        | 3 Years             | Silver, Space Gray                       |
| EcoFriendly Water Bottle | Sustainable water bottle               | BPA-Free, Double Wall Insulation, Leak-Proof   | $24.99           | Lifetime            | Blue, Green, Black                       |
| Fitness Tracker Pro    | Advanced fitness tracking device         | Heart Rate Monitor, GPS, Sleep Tracking, Water Resistant | $199.99          | 2 Years             | Pink, Black, Gray                        |

```markdown

| **Product Name**       | **Description**                          | **Features**                                   | **Price (USD)** | **Warranty Period** | **Available Colors**                    |
|------------------------|------------------------------------------|------------------------------------------------|------------------|---------------------|-----------------------------------------|
| UltraSmart TV 55"     | 4K Ultra HD Smart TV with voice control | 4K Resolution, HDR, Smart TV capabilities, Dolby Vision | $799.99          | 2 Years             | Black, Silver, Rose Gold                |
| PowerMax Blender       | High-performance kitchen blender          | 1200 Watts, 6-Speed Settings, Pulse Function   | $129.99          | 1 Year              | Red, Black, White                        |
| Quantum Laptop         | Lightweight and powerful laptop         | Intel i7, 16GB RAM, 512GB SSD, 15.6" Display  | $1,299.99        | 3 Years             | Silver, Space Gray                       |
| EcoFriendly Water Bottle | Sustainable water bottle               | BPA-Free, Double Wall Insulation, Leak-Proof   | $24.99           | Lifetime            | Blue, Green, Black                       |
| Fitness Tracker Pro    | Advanced fitness tracking device         | Heart Rate Monitor, GPS, Sleep Tracking, Water Resistant | $199.99          | 2 Years             | Pink, Black, Gray                        |
```

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
Before:
<img width="1126" height="810" alt="image" src="https://github.com/user-attachments/assets/8dae7cb5-98d3-496d-849d-2fadbec4e008" />

After:
<img width="1124" height="475" alt="image" src="https://github.com/user-attachments/assets/de955622-d01d-4d3a-80f5-95857c789e17" />

Other colours:
<img width="1043" height="369" alt="image" src="https://github.com/user-attachments/assets/c43cf3f2-8e5c-46bc-b35c-a815c5e39fc5" />
<img width="1037" height="370" alt="image" src="https://github.com/user-attachments/assets/6eb0241e-9b33-4b89-8963-33973640d933" />
<img width="1056" height="365" alt="image" src="https://github.com/user-attachments/assets/731c19f6-caf0-4f8a-b37e-c72cfa845df6" />

