### PR TITLE
fix: animation reload issue

### DIFF
--- a/src/components/PostPage.astro
+++ b/src/components/PostPage.astro
@@ -5,8 +5,8 @@ import PostCard from "./PostCard.astro";
 
 const { page } = Astro.props;
 
-let delay = 0;
-const interval = 50;
+// let delay = 0;
+// const interval = 50;
 ---
 <div class="transition flex flex-col rounded-[var(--radius-large)] bg-[var(--card-bg)] py-1 md:py-0 md:bg-transparent md:gap-4 mb-4">
     {page.data.map((entry: CollectionEntry<"posts">) => (
@@ -22,7 +22,8 @@ const interval = 50;
                 description={entry.data.description}
                 draft={entry.data.draft}
                 class:list="onload-animation"
-                style={`animation-delay: calc(var(--content-delay) + ${delay++ * interval}ms);`}
+                style={`animation-delay: var(--content-delay);`}
         ></PostCard>
+        <!-- style={`animation-delay: calc(var(--content-delay) + ${delay++ * interval}ms);`} -->
     ))}
 </div>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -4,6 +4,7 @@ declare global {
 	interface Window {
 		// type from '@swup/astro' is incorrect
 		swup: AstroIntegration;
+		stripOnloadAnimations?: () => void;
 		pagefind: {
 			search: (query: string) => Promise<{
 				results: Array<{

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -278,11 +278,13 @@ setClickOutsideToClose("search-panel", ["search-panel", "search-bar", "search-sw
 
 
 function loadTheme() {
+	// console.error('loadTheme CALLED! Stack:', new Error().stack);
 	const theme = getStoredTheme()
 	setTheme(theme)
 }
 
 function loadHue() {
+	// console.error('loadHue CALLED! Stack:', new Error().stack);
 	setHue(getHue())
 }
 
@@ -363,18 +365,73 @@ function showBanner() {
 	banner.classList.remove('opacity-0', 'scale-105');
 }
 
+const stripOnloadAnimations = () => {
+	let animationsDone = false;
+	try {
+		animationsDone = sessionStorage.getItem('onloadAnimationsDone') === '1';
+	} catch {}
+
+	const animated = document.querySelectorAll('.onload-animation');
+	if (animationsDone) {
+		animated.forEach(el => {
+			if (el instanceof HTMLElement) {
+				el.classList.remove('onload-animation');
+			}
+		});
+		return;
+	}
+
+	let finalized = false;
+	const finalize = () => {
+		if (finalized) return;
+		finalized = true;
+		try {
+			sessionStorage.setItem('onloadAnimationsDone', '1');
+		} catch {}
+		animated.forEach(el => {
+			if (el instanceof HTMLElement) {
+				el.classList.remove('onload-animation');
+			}
+		});
+	};
+
+	animated.forEach(el => {
+		if (!(el instanceof HTMLElement)) return;
+		el.addEventListener('animationend', finalize, { once: true });
+
+		const computed = window.getComputedStyle(el);
+		if (computed.animationDuration === '0s' || computed.animationName === 'none') {
+			finalize();
+		}
+	});
+};
+
+window.stripOnloadAnimations = stripOnloadAnimations;
+
 function init() {
 	// disableAnimation()()		// TODO
 	loadTheme();
 	loadHue();
-	initCustomScrollbar();
 	showBanner();
+
+	// Remove onload animations once they finish to prevent re-triggering
+	stripOnloadAnimations();
+	
+	// Delay initCustomScrollbar to after animations complete
+	setTimeout(() => {
+		initCustomScrollbar();
+	}, 600);
 }
 
 /* Load settings when entering the site */
 init();
 
 const setup = () => {
+	// Debug: Log all Swup events
+	// window.swup.hooks.on('visit:start', (visit) => {
+	// 	console.error('SWUP VISIT START:', visit.to.url, 'Stack:', new Error().stack);
+	// });
+
 	// TODO: temp solution to change the height of the banner
 /*
 	window.swup.hooks.on('animation:out:start', () => {
@@ -404,7 +461,10 @@ const setup = () => {
 			navbar.classList.add('navbar-hidden')
 		}
 	})
-	window.swup.hooks.on('content:replace', initCustomScrollbar)
+	window.swup.hooks.on('content:replace', () => {
+		initCustomScrollbar();
+		stripOnloadAnimations();
+	})
 	window.swup.hooks.on('visit:start', (visit: {to: {url: string}}) => {
 		// change banner height immediately when a link is clicked
 		const bodyElement = document.querySelector('body')


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
Fix: https://github.com/saicaca/fuwari/issues/637#issuecomment-3341158401


## Changes

<!-- Please describe the changes you made in this pull request. -->

1. Delay initialization of `initCustomScrollbar()` until after animations complete.
2. Remove staggered per-card `animation-delay` in `PostPage.astro`.
3. Add one‑time cleanup: `stripOnloadAnimations()` removes `.onload-animation` after the first animation ends.
4. Persist a session flag (`sessionStorage.onLoadAnimationsDone`) so later Swup navigations strip the class immediately.
5. Call `stripOnloadAnimations()` in Swup’s `content:replace` to handle newly injected DOM.

## How To Test

<!-- Please describe how you tested your changes. -->
Use DevTools to throttle traffic speed as 4G slow/3G to check if the page is still being reloaded.


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->

Root cause:
Swup swaps the page DOM without reloading assets. Elements that still have `.onload-animation` get reinserted on each `content:replace`, so the CSS keyframes restart and the navbar/post cards appear to “refresh” even though nothing is actually reloaded.

In conclusion: 
Animation class is the trigger. Removing `.onload-animation` after the first run stops keyframes from restarting when Swup replaces the DOM. A session flag preserves this behavior across in‑app navigations for the rest of the session.

<details>

<summary>Others</summary>

I had a really rough morning. After 11 hours of trying to find a complete fix (I was only able to partially mitigate it), I still couldn’t solve the problem. For the next 5 hours, the coding AI kept telling me there was no fix and urged me to give up. I hadn’t slept for nearly 24 hours and felt overwhelmed - almost like the AI was pressuring me.

So let me summarize how this happens.
The reason why I said this was not related to swup is because I remove the following code, as the solution was to remove swup (and then nothing resolved):
https://github.com/saicaca/fuwari/blob/6d39b0dec41282e7852e23e032998a5789abee28/astro.config.mjs#L36-L49

As of now, I asked GPT how this happens, and it told me the reason:
> Removing that Swup config block won’t stop the re‑animation because the trigger is **your CSS class and delays**, not the Swup integration settings. Swup only replaces the DOM; when `.onload-animation` stays on newly inserted elements, the keyframes restart. Even if you change or remove Swup options, the class is still applied on each replace, so the animation still “reloads.” 
> 
> Swup is working as designed. The fix is to **strip the animation class after first run** (and/or remove staggered delays), not to disable Swup or its config.


So, GPT seconds my initial conclusion, and I was partially right. But before I find out this, I was struggling on changing configuration like `config.cache`, `config.preload` for a long time (I totally have no idea what I am configuring as I don't have knowledge of this, so for a long time I thought this was my own problem), unless I find out none of these change anything and decide to disable the whole swup and find out the issue persists.

This is so despairing cuz I already spent hours on useless thing.

At the time, I decide to disable animation like what I mentioned in https://github.com/saicaca/fuwari/issues/637#issuecomment-3808096220:
```css
.onload-animation {
    opacity: 1;
    /* animation: 300ms fade-in-up; */
    /* animation-fill-mode: forwards; */
}
```

Since this started working, I began tracing the issue in `Layout.astro` and found that `initCustomScrollbar()` was causing the problem. More time passed.

But changing code of `initCustomScrollbar()` hit the dead end. I gave up, and the progress I made after then is as below:

```astro
setTimeout(() => {
	initCustomScrollbar();
	document.querySelectorAll('.onload-animation').forEach(el => {
		el.style.opacity = '1';	
		el.style.animation = 'none';
		el.style.transform = 'translateY(0)';
	});
}, 4000);
```

Summary from GPT:
> It waits 4000 ms, initializes the custom scrollbar, then forces all `.onload-animation` elements to a final, non‑animated state by setting `opacity: 1`, disabling `animation`, and resetting `transform` to `translateY(0)`. This prevents any further animation re‑triggering after that point.

Besides of this, I also remove staggered per-card `animation-delay` in `PostPage.astro`.

This solution will mitigate the issue: navbar no longer refresh but the post cards are now instant flashing. Whatever, already much better than fully reload.

But this is not full fix. This is mitigation. At the time I already gave up thinking anything and decide to hand in coding AI to let it made decision. And this is where the nightmare starts:
The coding AI tried some approaches, failed for another hour. And then told me to give up.
I changed to Copilot, and it asked me to use gsap.
I changed to whatever again, and it kept modifying "4000ms" to other values and asked me to build and test.
...

I was in high pressure because I kept being asking to give up and being given craps.

After watching the network tab and console log for a long time, the AI figures out that it can use sessionStorage to store a flag and then remove `onload-animation` class ([reference](https://stackoverflow.com/a/54327461/23507547)). 

Then the rest of the part is to refine the code and try to pass `astro check` as this is the correct approach.

During the whole debugging process, I built 79 times and lost patience partway through. Maybe the coding AI sensed something was off and told me to give up, that I will never know the true reason.

The next day I woke up and remembered what I’ve done before. I have just one comment:
I feel sorry for being a noob.

I’ve been using this blog theme for more than two years. I know I’m not a professional, but since no one fixed the issue, I had to do it myself. 
Even when it was actively maintained in the past, no one implemented fundamental enhancements like OG images.

When someone not professional like me have to do the professional thing, it is really driving me crazy.
Vibe coding helps me to learn, so I decided to trying fixing issue. I know "vibe coding" itself may trigger some kind of group, but what can I do when seeing a bug is not being fixed for 2 years when I am using it? I tried to avoid, but there is no other way. I can't just waste another year and then fix it because may be there will be another "another year" after that "another year".
<img width="1021" height="526" alt="image" src="https://github.com/user-attachments/assets/6ea93072-571b-487b-a268-3b9185061841" />
_(Caption: last commit of `initCustomScrollbar()`)_

So, I decide to do it now. I did the test, and not always follow what coding AI gives. I tried to think what the AI is giving me. I already did the best I can do.

I'm not sure when the maintainers will check this repository again. Maybe you could add a "Sponsor" section and use the service like Ko-fi to accept funds, if that would help maintain the project. Because no one knows when a noob like me have to deal with such bugs, what consequences (bugs) they can introduce. 


</details>

