### PR TITLE
feat: auto theme for expressive code

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -56,7 +56,7 @@ export default defineConfig({
 			},
 		}),
 		expressiveCode({
-			themes: [expressiveCodeConfig.theme, expressiveCodeConfig.theme],
+			// themes: [expressiveCodeConfig.theme, expressiveCodeConfig.theme],
 			plugins: [
 				pluginCollapsibleSections(),
 				pluginLineNumbers(),

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -57,6 +57,7 @@ export default defineConfig({
 		}),
 		expressiveCode({
 			// themes: [expressiveCodeConfig.theme, expressiveCodeConfig.theme],
+			themes: expressiveCodeConfig.themes,
 			plugins: [
 				pluginCollapsibleSections(),
 				pluginLineNumbers(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,5 +86,6 @@ export const licenseConfig: LicenseConfig = {
 export const expressiveCodeConfig: ExpressiveCodeConfig = {
 	// Note: Some styles (such as background color) are being overridden, see the astro.config.mjs file.
 	// Please select a dark theme, as this blog theme currently only supports dark background color
-	theme: "github-dark",
+	// theme: "github-dark",
+	themes: ["github-dark", "github-dark-dimmed"],
 };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -98,5 +98,6 @@ export type BlogPostData = {
 };
 
 export type ExpressiveCodeConfig = {
-	theme: string;
+	// theme: string;
+	themes: string[];
 };

--- a/src/utils/setting-utils.ts
+++ b/src/utils/setting-utils.ts
@@ -44,11 +44,16 @@ export function applyThemeToDocument(theme: LIGHT_DARK_MODE) {
 			break;
 	}
 
-	// Set the theme for Expressive Code
-	document.documentElement.setAttribute(
-		"data-theme",
-		expressiveCodeConfig.theme,
-	);
+	// Set the theme for Expressive Code (auto switch)
+	const themes = expressiveCodeConfig.themes || [];
+	const lightTheme = themes[0];
+	const darkTheme = themes.length > 1 ? themes[1] : themes[0];
+
+	const isDarkNow = document.documentElement.classList.contains("dark");
+	const autoTheme = isDarkNow ? darkTheme : lightTheme;
+	if (autoTheme) {
+		document.documentElement.setAttribute("data-theme", autoTheme);
+	}
 }
 
 export function setTheme(theme: LIGHT_DARK_MODE): void {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
None

## Changes

<!-- Please describe the changes you made in this pull request. -->
- Update `applyThemeToDocument()` to auto switch the Expressive Code theme by setting `data-theme` based on current light/dark state.
- Modified from `expressiveCodeConfig.theme` to `expressiveCodeConfig.themes` to contains two theme names.

## How To Test

<!-- Please describe how you tested your changes. -->
Switch between dark/light mode to see if code style (expressive code) inserted in the article is changed.

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
<img width="1054" height="879" alt="image" src="https://github.com/user-attachments/assets/0c039acf-6758-4880-80c3-34ddfb1022ad" />
<img width="1043" height="881" alt="image" src="https://github.com/user-attachments/assets/bf9216b4-7f35-4d07-83a3-b3598190658f" />


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
This should give users the chance to modify different dark themes for light/dark mode. Dark theme != dark theme in different environment. 

Personally I would love to add a border because it will make it more clear. But since that is a personal change, I did not include that in PR.
Without border:
<img width="1083" height="623" alt="image" src="https://github.com/user-attachments/assets/d26ff168-7ead-46fd-8277-3029e8321c2a" />

With border:
<img width="1090" height="632" alt="image" src="https://github.com/user-attachments/assets/03d39a3f-e454-4f0d-aa39-28a0d5650f56" />

```css
.expressive-code {
  .frame {
      @apply !shadow-none;
      border: 1px solid rgba(128, 128, 128, 0.2) !important;
      border-radius: 0.75rem;
  }

  .title {
      font-family: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
  }
}
```

