### PR TITLE
fix: astro check failure

### DIFF
--- a/src/components/ArchivePanel.svelte
+++ b/src/components/ArchivePanel.svelte
@@ -19,7 +19,7 @@ interface Post {
 	data: {
 		title: string;
 		tags: string[];
-		category?: string;
+		category?: string | null;
 		published: Date;
 	};
 }

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -51,6 +51,7 @@ let links: NavBarLink[] = navBarConfig.links.map(
                         <Icon name="material-symbols:palette-outline" class="text-[1.25rem]"></Icon>
                     </button>
             )}
+            {/* @ts-ignore */}
             <LightDarkSwitch client:only="svelte"></LightDarkSwitch>
             <button aria-label="Menu" name="Nav Menu" class="btn-plain scale-animation rounded-lg w-11 h-11 active:scale-90 md:!hidden" id="nav-menu-switch">
                 <Icon name="material-symbols:menu-rounded" class="text-[1.25rem]"></Icon>

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -9,6 +9,6 @@ const sortedPostsList = await getSortedPostsList();
 ---
 
 <MainGridLayout title={i18n(I18nKey.archive)}>
-    <ArchivePanel sortedPosts={sortedPostsList} client:only="svelte"></ArchivePanel>
+    <ArchivePanel tags={[]} categories={[]} sortedPosts={sortedPostsList} client:only="svelte"></ArchivePanel>
 </MainGridLayout>
 

--- a/src/plugins/expressive-code/language-badge.ts
+++ b/src/plugins/expressive-code/language-badge.ts
@@ -7,7 +7,7 @@ export function pluginLanguageBadge() {
 	return definePlugin({
 		name: "Language Badge",
 		// @ts-expect-error
-		baseStyles: ({ _cssVar }) => `
+		baseStyles: ({ _cssVar: _unused }) => `
       [data-language]::before {
         position: absolute;
         z-index: 2;


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
Fix: https://github.com/saicaca/fuwari/issues/722
Fix: https://github.com/saicaca/fuwari/issues/750

## Changes

<!-- Please describe the changes you made in this pull request. -->
1. Fix type compatibility in `ArchivePanel.svelte` by updating `category` to accept `string | null`.
2. Add `@ts-ignore` for `LightDarkSwitch` client directive in `Navbar.astro`.
3. Rename unused parameter in `language-badge.ts` to suppress warning.
4. Add required props to `ArchivePanel` in `archive.astro`. (required after applying fix 1)

Resolved errors/warnings:
```
src/pages/archive.astro:12:19 - error ts(2322): Type 'PostForList[]' is not assignable to type 'Post[]'.
  Type 'PostForList' is not assignable to type 'Post'.
    The types of 'data.category' are incompatible between these types.
      Type 'string | null' is not assignable to type 'string | undefined'.
        Type 'null' is not assignable to type 'string | undefined'.

12     <ArchivePanel sortedPosts={sortedPostsList} client:only="svelte"></ArchivePanel>
```

```
src/components/Navbar.astro:54:14 - error ts(2322): Type '{ "client:only": string; }' is not assignable to type 'IntrinsicAttributes & Record<string, never>'.
  Type '{ "client:only": string; }' is not assignable to type 'Record<string, never>'.
    Property 'client:only' is incompatible with index signature.
      Type 'string' is not assignable to type 'never'.

54             <LightDarkSwitch client:only="svelte"></LightDarkSwitch>
```

```
src/plugins/expressive-code/language-badge.ts:10:16 - warning ts(6133): '_cssVar' is declared but its value is never read.

10   baseStyles: ({ _cssVar }) => `
```

```
src/pages/archive.astro:12:6 - error ts(2322): Type '{ sortedPosts: PostForList[]; "client:only": string; }' is not assignable to type 'IntrinsicAttributes & { tags: string[]; categories: string[]; sortedPosts?: Post[] | undefined; } & { $$events?: { [evt: string]: CustomEvent<any>; } | undefined; $$slots?: {} | undefined; }'.
  Type '{ sortedPosts: PostForList[]; "client:only": string; }' is missing the following properties from type '{ tags: string[]; categories: string[]; sortedPosts?: Post[] | undefined; }': tags, categories

12     <ArchivePanel sortedPosts={sortedPostsList} client:only="svelte"></ArchivePanel>
```


## How To Test

<!-- Please describe how you tested your changes. -->
See the Astro Check result of this PR.

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
<img width="1155" height="629" alt="image" src="https://github.com/user-attachments/assets/db7053be-006b-4a6f-8b5e-976bde36cc8f" />

