### PR TITLE
feat: responsive main content width for large screens

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -139,7 +139,7 @@ const bannerOffset =
 		</script>
 		<style define:vars={{
 			configHue,
-			'page-width': `${PAGE_WIDTH}rem`,
+			'page-width': `clamp(${PAGE_WIDTH}rem, 75vw, 140rem)`,
 		}}></style>  <!-- defines global css variables. This will be applied to <html> <body> and some other elements idk why -->
 
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
None

## Changes

<!-- Please describe the changes you made in this pull request. -->
- Replace fixed `75rem` page width with `clamp(75rem, 75vw, 140rem)` so content scales proportionally on 1440p/4K displays instead of staying narrow.
https://github.com/saicaca/fuwari/blob/6d39b0dec41282e7852e23e032998a5789abee28/src/constants/constants.ts#L16-L17

## How To Test

<!-- Please describe how you tested your changes. -->
Use different screen resolution to check.

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
1080p:
<img width="1863" height="942" alt="image" src="https://github.com/user-attachments/assets/ef15762f-95f1-435f-ae7d-8bdd554f211c" />
4k: 
<img width="3790" height="2002" alt="image" src="https://github.com/user-attachments/assets/7e428910-d038-4ab6-8dc9-fbd5d5cfa8df" />


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
Should not be larger than `75vw` cuz `80vw` looks like below in 1080p:
<img width="1871" height="946" alt="image" src="https://github.com/user-attachments/assets/01ede145-6eae-469e-b2cb-7e3cc6d8d217" />
