### PR TITLE
feat: add swup navigation progress bar for long article loading

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -152,6 +152,7 @@ const bannerOffset =
 		  data-overlayscrollbars-initialize
 	>
 		<ConfigCarrier></ConfigCarrier>
+		<div id="swup-progress-bar" class="swup-progress-bar"></div>
 		<slot />
 
 		<!-- increase the page height during page transition to prevent the scrolling animation from jumping -->
@@ -164,6 +165,51 @@ const bannerOffset =
 	'banner-height-home': `${BANNER_HEIGHT_HOME}vh`,
 	'banner-height': `${BANNER_HEIGHT}vh`,
 }}>
+/* Swup navigation progress bar */
+.swup-progress-bar {
+	--progress-height: 3px;
+	--progress-duration: 8s;
+	--progress-hue-start: -30deg;
+	--progress-hue-end: 15deg;
+	--progress-glow: 0 0 8px oklch(0.7 0.15 var(--hue) / 0.6);
+
+	position: fixed;
+	top: 0;
+	left: 0;
+	height: var(--progress-height);
+	background: var(--primary);
+	z-index: 9999;
+	pointer-events: none;
+	width: 0;
+	opacity: 0;
+}
+.swup-progress-bar.is-loading {
+	opacity: 1;
+	animation: swup-progress var(--progress-duration) cubic-bezier(0.2, 0.5, 0, 1) forwards;
+	box-shadow: var(--progress-glow);
+}
+.swup-progress-bar.is-finishing {
+	opacity: 1;
+	width: 100% !important;
+	animation: none;
+	filter: hue-rotate(var(--progress-hue-end));
+	transition: width 0.2s ease-out;
+}
+.swup-progress-bar.is-done {
+	width: 100%;
+	opacity: 0;
+	animation: none;
+	filter: hue-rotate(var(--progress-hue-end));
+	transition: opacity 0.3s ease;
+}
+@keyframes swup-progress {
+	0% { width: 0; filter: hue-rotate(var(--progress-hue-start)); }
+	20% { width: 30%; }
+	50% { width: 60%; }
+	80% { width: 80%; }
+	100% { width: 95%; filter: hue-rotate(var(--progress-hue-end)); }
+}
+
 @tailwind components;
 @layer components {
 	.enable-banner.is-home #banner-wrapper {
@@ -387,6 +433,28 @@ const setup = () => {
 		}
 	})
 */
+	// Progress bar
+	window.swup.hooks.on('visit:start', () => {
+		const bar = document.getElementById('swup-progress-bar');
+		if (!bar) return;
+		bar.classList.remove('is-loading', 'is-finishing', 'is-done');
+		bar.style.width = '0';
+		void bar.offsetWidth; // force reflow to restart animation
+		bar.classList.add('is-loading');
+	});
+	window.swup.hooks.on('visit:end', () => {
+		const bar = document.getElementById('swup-progress-bar');
+		if (!bar) return;
+		// Phase 1: snap to 100%
+		bar.classList.remove('is-loading');
+		bar.classList.add('is-finishing');
+		// Phase 2: fade out after the width transition completes
+		setTimeout(() => {
+			bar.classList.remove('is-finishing');
+			bar.classList.add('is-done');
+		}, 250);
+	});
+
 	window.swup.hooks.on('link:click', () => {
 		// Remove the delay for the first time page load
 		document.documentElement.style.setProperty('--content-delay', '0ms')


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->

Resolve: https://github.com/saicaca/fuwari/issues/637
- Addresses the perceived freeze (4-5s) when navigating to long articles via swup, where the DOM replacement blocks the main thread with no visual indication of progress.



## Changes

<!-- Please describe the changes you made in this pull request. -->
- Add progress bar HTML element, CSS styles (loading animation, finishing, done states), and swup hook integration (`visit:start`, `visit:end`). The bar uses a CSS keyframe animation that gradually fills from 0% to 95% over 8 seconds, then snaps to 100% when the navigation completes.
- All tunable values are extracted into CSS custom properties (`--progress-height`, `--progress-duration`, `--progress-hue-start`, `--progress-hue-end`, `--progress-glow`) for easy customization.

## How To Test

<!-- Please describe how you tested your changes. -->
Use 3G mode to check while switching pages.

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
<img width="556" height="285" alt="image" src="https://github.com/user-attachments/assets/dc121a5d-ef7b-4d1e-962f-c382e8eb32bc" />
<img width="577" height="340" alt="image" src="https://github.com/user-attachments/assets/6e609ede-76ec-4b00-85f8-25e56a4dfe99" />

