### PR TITLE
fix: align GitHub syntax mapping with admonition types

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -107,7 +107,18 @@ export default defineConfig({
 			remarkMath,
 			remarkReadingTime,
 			remarkExcerpt,
-			remarkGithubAdmonitionsToDirectives,
+			[
+				remarkGithubAdmonitionsToDirectives,
+				{
+					mapping: {
+						NOTE: "note",
+						TIP: "tip",
+						IMPORTANT: "important",
+						CAUTION: "caution",
+						WARNING: "warning",
+					},
+				},
+			],
 			remarkDirective,
 			remarkSectionize,
 			parseDirectiveNode,


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
Close: https://github.com/saicaca/fuwari/issues/742

## Changes

<!-- Please describe the changes you made in this pull request. -->
- Remap in remark plugin config

## How To Test

<!-- Please describe how you tested your changes. -->
Add below to the test page:
```markdown
> [!IMPORTANT]
> The GitHub syntax is also supported.

> [!CAUTION]
> The GitHub syntax is also supported.

> [!WARNING]
> The GitHub syntax is also supported.

> [!NOTE]
> The GitHub syntax is also supported.

> [!TIP]
> The GitHub syntax is also supported.
```

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
<img width="852" height="607" alt="image" src="https://github.com/user-attachments/assets/736871d3-9390-4fb6-85e7-53b41d947ef2" />


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
Same fix but different approach: https://github.com/saicaca/fuwari/pull/645