### PR TITLE
[Fix] : resolve astro checks/CI recent failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@astrojs/check": "^0.9.6",
     "@astrojs/rss": "^4.0.14",
     "@astrojs/sitemap": "^3.6.0",
-    "@astrojs/svelte": "7.2.3",
+    "@astrojs/svelte": "7.2.0",
     "@astrojs/tailwind": "^6.0.2",
     "@expressive-code/core": "^0.41.4",
     "@expressive-code/plugin-collapsible-sections": "^0.41.4",

--- a/src/plugins/expressive-code/language-badge.ts
+++ b/src/plugins/expressive-code/language-badge.ts
@@ -6,8 +6,7 @@ import { definePlugin } from "@expressive-code/core";
 export function pluginLanguageBadge() {
 	return definePlugin({
 		name: "Language Badge",
-		// @ts-expect-error
-		baseStyles: ({ _cssVar }) => `
+		baseStyles: () => `
       [data-language]::before {
         position: absolute;
         z-index: 2;


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue
#722 
#750 


## Changes

Solved issues related to CI by fixing bugs in LightDarkSwitch and sortedPosts. Eliminated a declared unused variable to meet the criteria for astro check. This change will enable the GitHub Actions pipeline to be successful.


## How To Test

* Run `pnpm check` locally.
* Alternatively, **submit a PR** and `monitor` the GitHub Actions failure.


## Screenshots


<img width="936" height="202" alt="0_errors" src="https://github.com/user-attachments/assets/1911e66f-ec1b-4fd0-9326-1a576b147ea2" />

---

<img width="1419" height="105" alt="reason" src="https://github.com/user-attachments/assets/5bac38e5-b00f-432b-bb8f-9323ee2399d6" />

The decision to downgrade @astrojs/svelte to version 7.2.0 (previous fuwari version) is a strategic move to prioritize build stability over dependency adoption. Upgrading would only be necessary if a newer version optimized the size of the injected hydration script or fixed a bug with how props are passed.